### PR TITLE
docs: explain streaming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ stream.enqueue(
 ```
 
 Note that we are enquing our data onto Channel 1, with tags "name" and "batch".
+These are just examples, you can choose your own.
 
 ## Stream options
 
-Above, you saw an example using `NominalStreamOpts::default`. The
+Above, you saw an example using [`NominalStreamOpts::default`](https://docs.rs/nominal-streaming/latest/nominal_streaming/stream/struct.NominalStreamOpts.html). The
 following stream options can be set:
 
 ```rust
@@ -71,7 +72,7 @@ NominalStreamOpts {
 
 In this simplest case, we want to stream some values from memory into a [Nominal Dataset](https://docs.nominal.io/core/sdk/python-client/streaming/overview#streaming-data-to-a-dataset).
 
-Note that the `NominalCoreConsumer` requires the async [Tokio runtime](https://tokio.rs/).
+Note that the [`NominalCoreConsumer`](https://docs.rs/nominal-streaming/latest/nominal_streaming/consumer/struct.NominalCoreConsumer.html) requires the async [Tokio runtime](https://tokio.rs/).
 
 ```rust
 use nominal_streaming::prelude::*;
@@ -208,6 +209,13 @@ tracing_subscriber::registry()
         .from_env_lossy()
 )
 .init();
+```
+
+And add the necessary tracing dependencies to `Cargo.toml`:
+
+```toml
+tracing = "^0.1"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 ```
 
 If you want to avoid printing full tracebacks for errors, customize the error printing:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ You can view the crate documentation at https://docs.rs/nominal-streaming/latest
 
 ## Conceptual overview
 
-first an "overview" for general usage pattern, which is "create consumers for the points, then create the NominalDatasourceStream and enqueue points" - with minimal/one-line code snippets
-then, a "streaming to Nominal Core" section, which specifically uses the NominalCoreConsumer + mentions the need for a tokio runtime
-
 Data points will be sent to a Consumer.
 The Consumer is responsible for, e.g., sending the data to Nominal Core, or for saving it to disk.
 A [NominalDatasourceStream](https://docs.rs/nominal-streaming/latest/nominal_streaming/stream/struct.NominalDatasourceStream.html) is the mechanism by which data points are fed to the consumer.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can view the crate documentation at https://docs.rs/nominal-streaming/latest
 
 Data points will be sent to a Consumer.
 The Consumer is responsible for, e.g., sending the data to Nominal Core, or for saving it to disk.
-A [NominalDatasourceStream](https://docs.rs/nominal-streaming/latest/nominal_streaming/stream/struct.NominalDatasourceStream.html) is the mechanism by which data points are fed to the consumer.
+A [`NominalDatasourceStream`](https://docs.rs/nominal-streaming/latest/nominal_streaming/stream/struct.NominalDatasourceStream.html) is the mechanism by which data points are fed to the consumer.
 
 We construct a stream from a consumer as follows:
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ async fn async_main() {
         NominalStreamOpts::default()
     );
 
-    // Generate 500 batches of test data, each containing 100,000 data points
+    // Generate 50 batches of test data, each containing 100,000 data points
     for batch in 0..50 {
         let mut points = Vec::new();
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nominal Streaming
 
-nominal-streaming is a Rust library for streaming data into Nominal Core.
+`nominal-streaming` is a Rust library for streaming data into Nominal Core.
 
 The library aims to balance three concerns:
 1. Data should exist in-memory only for a limited, configurable amount of time before it's sent to Core.
@@ -9,5 +9,120 @@ The library aims to balance three concerns:
 
 The library provides configuration points to manage the tradeoff between these concerns.
 
-> [!WARNING]  
+> [!WARNING]
 > This library is still under active development and may make breaking changes.
+
+You can view the crate documentation at https://docs.rs/nominal-streaming/latest/nominal_streaming/
+
+## Concepts
+
+While streaming, there will be a provider (the origin of the data) and a consumer (which receives the data).
+E.g., when streaming to the Nominal platform, we will be streaming from memory into a `NominalCoreConsumer`.
+
+## Stream options
+
+Below, you will see examples using `NominalStreamOpts::default`. The following stream options can be set:
+
+```rust
+NominalStreamOpts {
+  max_points_per_record: usize,
+  max_request_delay: Duration,
+  max_buffered_requests: usize,
+  request_dispatcher_tasks: usize,
+}
+```
+
+## Usage examples
+
+### Streaming from memory to Nominal
+
+In this simplest case, we want to stream some values from memory in a [Nominal Dataset](https://docs.nominal.io/core/sdk/python-client/streaming/overview#streaming-data-to-a-dataset).
+
+```rust
+use nominal_streaming::NominalDatasourceStream;
+use nominal_streaming::api::{
+    BearerToken, ResourceIdentifier, Timestamp, DoublePoint
+};
+use nominal_streaming::client::STAGING_STREAMING_CLIENT;
+use nominal_streaming::consumer::NominalCoreConsumer;
+use nominal_streaming::stream::NominalStreamOpts;
+
+use std::time::UNIX_EPOCH;
+use std::collections::HashMap;
+
+
+static DATA_SOURCE_RID: &str =
+      "ri.catalog.gov-staging.dataset.d61e3cf9-094b-4612-9c1d-619b48c335f9";
+
+
+fn core_consumer() -> NominalCoreConsumer<BearerToken> {
+    let token = BearerToken::new(
+        std::env::var("NOMINAL_TOKEN")
+            .expect("NOMINAL_TOKEN environment variable not set")
+            .as_str(),
+    )
+    .expect("Invalid token");
+
+    let data_source_rid = ResourceIdentifier::new(DATA_SOURCE_RID).unwrap();
+
+    NominalCoreConsumer::new(
+        STAGING_STREAMING_CLIENT.clone(),
+        tokio::runtime::Handle::current(),
+        token.clone(),
+        data_source_rid.clone(),
+    )
+}
+
+
+fn main() {
+    // Standard scaffolding for multi-threaded app
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(4)
+        .thread_name("tokio")
+        .build()
+        .expect("Failed to create Tokio runtime")
+        .block_on(async_main());
+}
+
+
+async fn async_main() {
+    let stream = NominalDatasourceStream::new_with_consumer(
+        core_consumer(),
+        NominalStreamOpts::default()
+    );
+
+    // Generate 500 batches of test data, each containing 100,000 data points
+    for batch in 0..50 {
+        let mut points = Vec::new();
+
+        for i in 0..100_000 {
+            let start_time = UNIX_EPOCH.elapsed().unwrap();
+            points.push(DoublePoint {
+                timestamp: Some(Timestamp {
+                    seconds: start_time.as_secs() as i64,
+                    nanos: start_time.subsec_nanos() as i32 + i,
+                }),
+                value: (i % 50) as f64,
+            });
+        }
+
+        // Push current batch onto the upload queue
+        println!("Enqueue batch: {}", batch);
+        stream.enqueue(
+            "channel_1".into(),
+            HashMap::from([("batch_id".to_string(), batch.to_string())]),
+            points,
+        );
+    }
+}
+```
+
+The `Cargo.toml` will contain the following dependencies:
+
+```toml
+[dependencies]
+nominal-api = "0.867.0"
+nominal-streaming = "0.1.1"
+tokio = { version = "1", features = ["full", "tracing"] }
+```

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ use nominal_streaming::prelude::*;
 use std::time::UNIX_EPOCH;
 
 
-static DATA_SOURCE_RID: &str =
-      "ri.catalog.gov-staging.dataset.d61e3cf9-094b-4612-9c1d-619b48c335f9";
+static DATA_SOURCE_RID: &str = "<your-datasource-rid-here>";
 
 
 fn core_consumer() -> NominalCoreConsumer<BearerToken> {
@@ -103,7 +102,7 @@ fn core_consumer() -> NominalCoreConsumer<BearerToken> {
 
 
 fn main() {
-    // Standard scaffolding for multi-threaded app
+    // The NominalCoreConsumer requires a tokio runtime
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .worker_threads(4)

--- a/README.md
+++ b/README.md
@@ -39,16 +39,8 @@ NominalStreamOpts {
 In this simplest case, we want to stream some values from memory in a [Nominal Dataset](https://docs.nominal.io/core/sdk/python-client/streaming/overview#streaming-data-to-a-dataset).
 
 ```rust
-use nominal_streaming::NominalDatasourceStream;
-use nominal_streaming::api::{
-    BearerToken, ResourceIdentifier, Timestamp, DoublePoint
-};
-use nominal_streaming::client::STAGING_STREAMING_CLIENT;
-use nominal_streaming::consumer::NominalCoreConsumer;
-use nominal_streaming::stream::NominalStreamOpts;
-
+use nominal_streaming::prelude::*;
 use std::time::UNIX_EPOCH;
-use std::collections::HashMap;
 
 
 static DATA_SOURCE_RID: &str =
@@ -110,8 +102,7 @@ async fn async_main() {
         // Push current batch onto the upload queue
         println!("Enqueue batch: {}", batch);
         stream.enqueue(
-            "channel_1".into(),
-            HashMap::from([("batch_id".to_string(), batch.to_string())]),
+            &ChannelDescriptor::new("channel_1", [("batch_id", batch.to_string())]),
             points,
         );
     }
@@ -123,6 +114,6 @@ The `Cargo.toml` will contain the following dependencies:
 ```toml
 [dependencies]
 nominal-api = "0.867.0"
-nominal-streaming = "0.1.1"
+nominal-streaming = "0.2.0"
 tokio = { version = "1", features = ["full", "tracing"] }
 ```

--- a/README.md
+++ b/README.md
@@ -235,3 +235,21 @@ impl NominalStreamListener for MyListener {
 
 let stream = ListeningWriteRequestConsumer::new(core_consumer(), vec![Arc::new(MyListener)]);
 ```
+
+## The builder interface
+
+The latest version of `nominal-streaming` contains a [builder interface](https://docs.rs/nominal-streaming/latest/nominal_streaming/stream/struct.NominalDatasetStream.html#method.builder) to make all of the above simpler.
+
+E.g., you can now do:
+
+```rust
+use nominal_streaming::stream::NominalDatasetStreamBuilder;
+
+let handle = tokio::runtime::Handle::current();
+let dataset_rid = ResourceIdentifier::new(DATASET_RID).unwrap();
+
+let stream = NominalDatasetStreamBuilder::new()
+  .stream_to_core(token, dataset_rid, handle)
+  .with_file_fallback("/tmp/fallback.avro")
+  .build();
+```


### PR DESCRIPTION
Questions:

- [x] Is this the simplest possible example?
- [x] This seems to succeed, even if the token does not have access to the data source. Is the simplest mechanism to report that full-fledged logging?
- [x] The concepts section can be improved to capture all the relevant topics.
- [x] In the Python API, we typically stream into a `Dataset`. Should we match that here, instead of using `Datasource`?
- [x] Example would probably better if time started now, instead of beginning of epoch.
