### PR TITLE
feat: add a `prelude` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,8 @@ pub mod consumer;
 pub mod notifier;
 pub mod stream;
 
-pub use stream::NominalDatasourceStream;
-
-pub mod api {
+/// This includes the most common types in this crate, re-exported for your convenience.
+pub mod prelude {
     pub use conjure_object::BearerToken;
     pub use conjure_object::ResourceIdentifier;
     pub use nominal_api::tonic::google::protobuf::Timestamp;
@@ -16,6 +15,13 @@ pub mod api {
     pub use nominal_api::tonic::io::nominal::scout::api::proto::StringPoints;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequest;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequestNominal;
+
+    pub use crate::client::PRODUCTION_STREAMING_CLIENT;
+    pub use crate::client::STAGING_STREAMING_CLIENT;
+    pub use crate::consumer::NominalCoreConsumer;
+    pub use crate::stream::ChannelDescriptor;
+    pub use crate::stream::NominalDatasourceStream;
+    pub use crate::stream::NominalStreamOpts;
 }
 
 #[cfg(test)]
@@ -23,12 +29,9 @@ mod tests {
     use std::sync::Mutex;
     use std::time::UNIX_EPOCH;
 
-    use crate::api::*;
     use crate::consumer::ConsumerResult;
     use crate::consumer::WriteRequestConsumer;
-    use crate::stream::ChannelDescriptor;
-    use crate::stream::NominalStreamOpts;
-    use crate::NominalDatasourceStream;
+    use crate::prelude::*;
 
     #[derive(Debug)]
     struct TestDatasourceStream {


### PR DESCRIPTION
Goal here is to export the most common types so that you can do

```rust
use nominal_streaming::prelude::*;
```

the core idea being that users will most likely want to import all/most of these types anyway. Note that I've removed the `api` module in favor of this.