### PR TITLE
feat: rename datasource to dataset and add builder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prelude {
     pub use crate::client::STAGING_STREAMING_CLIENT;
     pub use crate::consumer::NominalCoreConsumer;
     pub use crate::stream::ChannelDescriptor;
-    pub use crate::stream::NominalDatasourceStream;
+    pub use crate::stream::NominalDatasetStream;
     pub use crate::stream::NominalStreamOpts;
 }
 
@@ -51,7 +51,7 @@ mod tests {
             requests: Mutex::new(vec![]),
         });
         let test_consumer = Box::leak(test_consumer);
-        let stream = NominalDatasourceStream::new_with_consumer(
+        let stream = NominalDatasetStream::new_with_consumer(
             &*test_consumer,
             NominalStreamOpts {
                 max_points_per_record: 1000,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod prelude {
     pub use crate::client::STAGING_STREAMING_CLIENT;
     pub use crate::consumer::NominalCoreConsumer;
     pub use crate::stream::ChannelDescriptor;
+    pub use crate::stream::NominalDatasourceStream;
     pub use crate::stream::NominalDatasetStream;
     pub use crate::stream::NominalStreamOpts;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ pub mod prelude {
     pub use crate::client::STAGING_STREAMING_CLIENT;
     pub use crate::consumer::NominalCoreConsumer;
     pub use crate::stream::ChannelDescriptor;
-    pub use crate::stream::NominalDatasourceStream;
     pub use crate::stream::NominalDatasetStream;
+    pub use crate::stream::NominalDatasourceStream;
     pub use crate::stream::NominalStreamOpts;
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -228,6 +228,10 @@ pub struct NominalDatasetStream {
 }
 
 impl NominalDatasetStream {
+    pub fn builder() -> NominalDatasetStreamBuilder {
+        NominalDatasetStreamBuilder::new()
+    }
+
     pub fn new_with_consumer<C: WriteRequestConsumer + 'static>(
         consumer: C,
         opts: NominalStreamOpts,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -218,6 +218,10 @@ impl NominalDatasetStreamBuilder {
 
 }
 
+// for backcompat, new code should use NominalDatasetStream
+#[deprecated]
+pub type NominalDatasourceStream = NominalDatasetStream;
+
 pub struct NominalDatasetStream {
     running: Arc<AtomicBool>,
     unflushed_points: Arc<AtomicUsize>,


### PR DESCRIPTION
* rename NominalDatasourceStream to NominalDatasetStream
* add NominalDatasetStream::builder() for constructing streams with logging / etc enabled more easily
* create (deprecated) type alias for NominalDatasourceStream to avoid immediate compile-breaks