### PR TITLE
feat: add feature for enabling logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- Library crate lives under `src/` with `lib.rs` re-exporting the main modules.
+- `src/consumer.rs`, `src/stream.rs`, and `src/client.rs` handle the streaming pipeline and external I/O.
+- Supporting utilities sit in `src/types.rs` and `src/notifier.rs`; place new helper types alongside these.
+- Integration tests live inline with modules via `#[cfg(test)]`; add new tests next to the code they cover.
+
+## Build, Test, and Development Commands
+
+- `cargo build` compiles the library and ensures new APIs integrate cleanly.
+- `cargo test` runs unit tests (with `test-log` enabled) and should pass before every push.
+- `cargo +nightly fmt --all` applies the repository rustfmt settings; run before committing.
+- `cargo clippy --all-targets --all-features` catches common mistakes; address warnings or justify them.
+- `cargo doc --open` renders API docs; check public items for clarity when adding features.
+
+## Coding Style & Naming Conventions
+
+- Use Rust 2021 idioms, keeping modules single-purpose and aligned with filenames.
+- Functions and module-level helpers use `snake_case`; types and traits use `PascalCase`; constants stay `SCREAMING_SNAKE_CASE`.
+- Use `tracing` macros for logging and instrumentation.
+- Keep async code on Tokio-friendly APIs; clone handles instead of creating ad-hoc runtimes.
+
+## Testing Guidelines
+
+- Co-locate tests in `mod tests` blocks using descriptive function names like `handles_disk_fallback`.
+- Unit tests should cover specific functionality, integration and end-to-end tests are not required.
+- Mock external clients with in-memory channels; avoid network calls in CI.
+- Cover both happy paths and failure recovery (e.g., disk fallback, retry logic).
+- Run `cargo test -- --nocapture` when debugging to view output.
+
+## Commit & Pull Request Guidelines
+
+- Use Conventional Commit prefixes (`feat:`, `fix:`, `chore:`, `docs:`) mirroring existing history and reference issues as `(#123)` when applicable.
+- PR descriptions should include a concise summary, motivation for the change, and the commands/tests executed (paste output when failure-driven).
+
+## Security & Configuration Tips
+
+- Never commit tokens or dataset identifiers; load them via `NOMINAL_TOKEN` and other environment variables at runtime.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -2469,6 +2470,7 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "Library for durable, low-latency streaming into Nominal Core"
 license = "MIT"
 
+[features]
+default = ["logging"]
+logging = ["tracing-subscriber"]
+
 [dependencies]
 conjure-error = "4"
 conjure-http = "4"
@@ -17,7 +21,7 @@ tokio = { version = "1", features = ["full", "tracing"] }
 url = "2.5.4"
 parking_lot = "0.12"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3", optional = true, features = ["fmt", "env-filter"] }
 apache-avro = { version = "0.17.0", features = ["snappy"] }
 derive_more = { version = "2", features = ["from"] }
 serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1", features = ["full", "tracing"] }
 url = "2.5.4"
 parking_lot = "0.12"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 apache-avro = { version = "0.17.0", features = ["snappy"] }
 derive_more = { version = "2", features = ["from"] }
 serde_json = "1.0.140"

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -27,7 +27,6 @@ use parking_lot::MutexGuard;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
-use tracing::level_filters::LevelFilter;
 use tracing::warn;
 
 use crate::client::PRODUCTION_STREAMING_CLIENT;
@@ -100,7 +99,8 @@ impl NominalDatasetStreamBuilder {
         self
     }
 
-    pub fn enable_logging(self, level: LevelFilter) -> Self {
+    #[cfg(feature = "logging")]
+    pub fn enable_logging(self, level: tracing::level_filters::LevelFilter) -> Self {
         use tracing_subscriber::layer::SubscriberExt;
         use tracing_subscriber::util::SubscriberInitExt;
 
@@ -113,7 +113,7 @@ impl NominalDatasetStreamBuilder {
             .with(tracing_subscriber::fmt::layer());
 
         if let Err(error) = subscriber.try_init() {
-            eprintln!("failed to initialize tracing subscriber: {error}");
+            eprintln!("nominal streaming failed to enabled logging: {error}");
         }
 
         self

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -99,14 +99,14 @@ impl NominalDatasetStreamBuilder {
     }
 
     #[cfg(feature = "logging")]
-    pub fn enable_logging(self, level: tracing::level_filters::LevelFilter) -> Self {
+    pub fn enable_logging(self) -> Self {
         use tracing_subscriber::layer::SubscriberExt;
         use tracing_subscriber::util::SubscriberInitExt;
 
         let subscriber = tracing_subscriber::registry()
             .with(
                 tracing_subscriber::EnvFilter::builder()
-                    .with_default_directive(level.into())
+                    .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
                     .from_env_lossy(),
             )
             .with(tracing_subscriber::fmt::layer());


### PR DESCRIPTION
* adds an agent.md file for codex/etc
* adds a default feature for `enable_logging`, can be disabled in environments where bringing in the tracing_subscriber dependency is undesirable

undecided if the feature should be default or not - but can remove in future if it causes confusion/dependency conflicts