### PR TITLE
refactor: add SeriesBufferInner type

### DIFF
--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -714,8 +714,9 @@ impl SeriesBuffer {
 }
 
 mod inner {
-    use super::*;
     use parking_lot::Mutex;
+
+    use super::*;
 
     pub(super) struct SeriesBufferInner {
         points: Mutex<HashMap<ChannelDescriptor, PointsType>>,


### PR DESCRIPTION
This PR moves two fields of `SeriesBuffer` into a new type, `SeriesBufferInner`, the moves this type to a module `inner`. This inner type provides/controls access to:
- the points buffer (write, mutex-guarded)
- the count (read-only, atomic)

The `inner` module restricts direct access to these struct members, requiring access through `SeriesBufferInner`'s API.

The intent is for:
- updates to the points buffer can be slow and must be coherent
- reads / checks to the points are fast (do not require locking)

For the motivation behind this PR, see #139.