### PR TITLE
refactor: extract SeriesBuffer, add SeriesBufferInner

### DIFF
--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -158,6 +158,7 @@ let stream = NominalDatasetStreamBuilder::new()
 pub mod client;
 pub mod consumer;
 pub mod listener;
+mod series_buffer;
 pub mod stream;
 mod types;
 pub mod upload;

--- a/nominal-streaming/src/series_buffer.rs
+++ b/nominal-streaming/src/series_buffer.rs
@@ -1,0 +1,251 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::UNIX_EPOCH;
+
+use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
+use nominal_api::tonic::io::nominal::scout::api::proto::points::PointsType;
+use nominal_api::tonic::io::nominal::scout::api::proto::ArrayPoints;
+use nominal_api::tonic::io::nominal::scout::api::proto::Channel;
+use nominal_api::tonic::io::nominal::scout::api::proto::Points;
+use nominal_api::tonic::io::nominal::scout::api::proto::Series;
+use parking_lot::Condvar;
+use parking_lot::Mutex;
+use parking_lot::MutexGuard;
+use tracing::debug;
+
+use crate::prelude::ChannelDescriptor;
+use crate::types::IntoPoints;
+use crate::types::PointsTypeExt;
+
+pub(crate) struct SeriesBuffer {
+    points: Mutex<HashMap<ChannelDescriptor, PointsType>>,
+    count: AtomicUsize,
+    flush_time: AtomicU64,
+    condvar: Condvar,
+    max_capacity: usize,
+}
+
+pub(crate) struct SeriesBufferGuard<'sb> {
+    sb: MutexGuard<'sb, HashMap<ChannelDescriptor, PointsType>>,
+    count: &'sb AtomicUsize,
+}
+
+impl SeriesBufferGuard<'_> {
+    pub(crate) fn extend(
+        &mut self,
+        channel_descriptor: &ChannelDescriptor,
+        points: impl IntoPoints,
+    ) {
+        let points = points.into_points();
+        let new_point_count = points.len();
+
+        if !self.sb.contains_key(channel_descriptor) {
+            self.sb.insert(channel_descriptor.clone(), points);
+        } else {
+            match (self.sb.get_mut(channel_descriptor).unwrap(), points) {
+                (PointsType::DoublePoints(existing), PointsType::DoublePoints(new)) => {
+                    existing.points.extend(new.points)
+                }
+                (PointsType::StringPoints(existing), PointsType::StringPoints(new)) => {
+                    existing.points.extend(new.points)
+                }
+                (PointsType::IntegerPoints(existing), PointsType::IntegerPoints(new)) => {
+                    existing.points.extend(new.points)
+                }
+                (
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(ArrayType::DoubleArrayPoints(existing)),
+                    }),
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(ArrayType::DoubleArrayPoints(new)),
+                    }),
+                ) => existing.points.extend(new.points),
+                (
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(ArrayType::StringArrayPoints(existing)),
+                    }),
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(ArrayType::StringArrayPoints(new)),
+                    }),
+                ) => existing.points.extend(new.points),
+                (
+                    PointsType::ArrayPoints(ArrayPoints { array_type: None }),
+                    PointsType::ArrayPoints(ArrayPoints { array_type: None }),
+                ) => {}
+                (PointsType::StructPoints(existing), PointsType::StructPoints(new)) => {
+                    existing.points.extend(new.points);
+                }
+                // this is hideous, but exhaustive matching is good to avoid future errors
+                (
+                    PointsType::DoublePoints(_),
+                    PointsType::IntegerPoints(_)
+                    | PointsType::StringPoints(_)
+                    | PointsType::ArrayPoints(_)
+                    | PointsType::StructPoints(_),
+                )
+                | (
+                    PointsType::StringPoints(_),
+                    PointsType::DoublePoints(_)
+                    | PointsType::IntegerPoints(_)
+                    | PointsType::ArrayPoints(_)
+                    | PointsType::StructPoints(_),
+                )
+                | (
+                    PointsType::IntegerPoints(_),
+                    PointsType::DoublePoints(_)
+                    | PointsType::StringPoints(_)
+                    | PointsType::ArrayPoints(_)
+                    | PointsType::StructPoints(_),
+                )
+                | (
+                    PointsType::ArrayPoints(_),
+                    PointsType::DoublePoints(_)
+                    | PointsType::StringPoints(_)
+                    | PointsType::IntegerPoints(_)
+                    | PointsType::StructPoints(_),
+                )
+                | (
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(_),
+                    }),
+                    PointsType::ArrayPoints(ArrayPoints { array_type: None }),
+                )
+                | (
+                    PointsType::ArrayPoints(ArrayPoints { array_type: None }),
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(_),
+                    }),
+                )
+                | (
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(ArrayType::DoubleArrayPoints(_)),
+                    }),
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(ArrayType::StringArrayPoints(_)),
+                    }),
+                )
+                | (
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(ArrayType::StringArrayPoints(_)),
+                    }),
+                    PointsType::ArrayPoints(ArrayPoints {
+                        array_type: Some(ArrayType::DoubleArrayPoints(_)),
+                    }),
+                )
+                | (
+                    PointsType::StructPoints(_),
+                    PointsType::DoublePoints(_)
+                    | PointsType::StringPoints(_)
+                    | PointsType::IntegerPoints(_)
+                    | PointsType::ArrayPoints(_),
+                ) => {
+                    // todo: improve error
+                    panic!("mismatched types");
+                }
+            }
+        }
+
+        self.count.fetch_add(new_point_count, Ordering::Release);
+    }
+}
+
+impl PartialEq for SeriesBuffer {
+    fn eq(&self, other: &Self) -> bool {
+        self.flush_time.load(Ordering::Acquire) == other.flush_time.load(Ordering::Acquire)
+    }
+}
+
+impl PartialOrd for SeriesBuffer {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let flush_time = self.flush_time.load(Ordering::Acquire);
+        let other_flush_time = other.flush_time.load(Ordering::Acquire);
+        flush_time.partial_cmp(&other_flush_time)
+    }
+}
+
+impl SeriesBuffer {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            points: Mutex::new(HashMap::new()),
+            count: AtomicUsize::new(0),
+            flush_time: AtomicU64::new(0),
+            condvar: Condvar::new(),
+            max_capacity: capacity,
+        }
+    }
+
+    /// Checks if the buffer has enough capacity to add new points.
+    /// Note that the buffer can be larger than MAX_POINTS_PER_RECORD if a single batch of points
+    /// larger than MAX_POINTS_PER_RECORD is inserted while the buffer is empty. This avoids needing
+    /// to handle splitting batches of points across multiple requests.
+    pub(crate) fn has_capacity(&self, new_points_count: usize) -> bool {
+        let count = self.count.load(Ordering::Acquire);
+        count == 0 || count + new_points_count <= self.max_capacity
+    }
+
+    pub(crate) fn lock(&self) -> SeriesBufferGuard<'_> {
+        SeriesBufferGuard {
+            sb: self.points.lock(),
+            count: &self.count,
+        }
+    }
+
+    pub(crate) fn take(&self) -> (usize, Vec<Series>) {
+        let mut points = self.lock();
+        self.flush_time.store(
+            UNIX_EPOCH.elapsed().unwrap().as_nanos() as u64,
+            Ordering::Release,
+        );
+        let result = points
+            .sb
+            .drain()
+            .map(|(ChannelDescriptor { name, tags }, points)| {
+                let channel = Channel { name };
+                let points_obj = Points {
+                    points_type: Some(points),
+                };
+                Series {
+                    channel: Some(channel),
+                    tags: tags
+                        .map(|tags| tags.into_iter().collect())
+                        .unwrap_or_default(),
+                    points: Some(points_obj),
+                }
+            })
+            .collect();
+        let result_count = self
+            .count
+            .fetch_update(Ordering::Release, Ordering::Acquire, |_| Some(0))
+            .unwrap();
+        (result_count, result)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.count() == 0
+    }
+
+    pub(crate) fn count(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn on_notify(&self, on_notify: impl FnOnce(SeriesBufferGuard)) {
+        let mut points_lock = self.points.lock();
+        // concurrency bug without this - the buffer could have been emptied since we
+        // checked the count, so this will wait forever & block any new points from entering
+        if !points_lock.is_empty() {
+            self.condvar.wait(&mut points_lock);
+        } else {
+            debug!("buffer emptied since last check, skipping condvar wait");
+        }
+        on_notify(SeriesBufferGuard {
+            sb: points_lock,
+            count: &self.count,
+        });
+    }
+
+    pub(crate) fn notify(&self) -> bool {
+        self.condvar.notify_one()
+    }
+}

--- a/nominal-streaming/src/series_buffer.rs
+++ b/nominal-streaming/src/series_buffer.rs
@@ -20,11 +20,15 @@ use crate::types::IntoPoints;
 use crate::types::PointsTypeExt;
 
 pub(crate) struct SeriesBuffer {
-    points: Mutex<HashMap<ChannelDescriptor, PointsType>>,
-    count: AtomicUsize,
+    inner: SeriesBufferInner,
     flush_time: AtomicU64,
     condvar: Condvar,
     max_capacity: usize,
+}
+
+struct SeriesBufferInner {
+    points: Mutex<HashMap<ChannelDescriptor, PointsType>>,
+    count: AtomicUsize,
 }
 
 pub(crate) struct SeriesBufferGuard<'sb> {
@@ -193,8 +197,7 @@ impl PartialOrd for SeriesBuffer {
 impl SeriesBuffer {
     pub(crate) fn new(capacity: usize) -> Self {
         Self {
-            points: Mutex::new(HashMap::new()),
-            count: AtomicUsize::new(0),
+            inner: SeriesBufferInner::new(),
             flush_time: AtomicU64::new(0),
             condvar: Condvar::new(),
             max_capacity: capacity,
@@ -206,15 +209,12 @@ impl SeriesBuffer {
     /// larger than MAX_POINTS_PER_RECORD is inserted while the buffer is empty. This avoids needing
     /// to handle splitting batches of points across multiple requests.
     pub(crate) fn has_capacity(&self, new_points_count: usize) -> bool {
-        let count = self.count.load(Ordering::Acquire);
+        let count = self.count();
         count == 0 || count + new_points_count <= self.max_capacity
     }
 
     pub(crate) fn lock(&self) -> SeriesBufferGuard<'_> {
-        SeriesBufferGuard {
-            sb: self.points.lock(),
-            count: &self.count,
-        }
+        self.inner.lock()
     }
 
     pub(crate) fn take(&self) -> (usize, Vec<Series>) {
@@ -227,29 +227,50 @@ impl SeriesBuffer {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.count() == 0
+        self.inner.is_empty()
     }
 
     pub(crate) fn count(&self) -> usize {
-        self.count.load(Ordering::Acquire)
+        self.inner.count()
     }
 
     pub(crate) fn on_notify(&self, on_notify: impl FnOnce(SeriesBufferGuard)) {
-        let mut points_lock = self.points.lock();
+        let mut guard = self.inner.lock();
         // concurrency bug without this - the buffer could have been emptied since we
         // checked the count, so this will wait forever & block any new points from entering
-        if !points_lock.is_empty() {
-            self.condvar.wait(&mut points_lock);
+        if !guard.sb.is_empty() {
+            self.condvar.wait(&mut guard.sb);
         } else {
             debug!("buffer emptied since last check, skipping condvar wait");
         }
-        on_notify(SeriesBufferGuard {
-            sb: points_lock,
-            count: &self.count,
-        });
+        on_notify(guard);
     }
 
     pub(crate) fn notify(&self) -> bool {
         self.condvar.notify_one()
+    }
+}
+
+impl SeriesBufferInner {
+    fn new() -> Self {
+        Self {
+            points: Mutex::new(HashMap::new()),
+            count: AtomicUsize::new(0),
+        }
+    }
+
+    fn count(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.count() == 0
+    }
+
+    fn lock(&self) -> SeriesBufferGuard<'_> {
+        SeriesBufferGuard {
+            sb: self.points.lock(),
+            count: &self.count,
+        }
     }
 }

--- a/nominal-streaming/src/series_buffer.rs
+++ b/nominal-streaming/src/series_buffer.rs
@@ -149,6 +149,31 @@ impl SeriesBufferGuard<'_> {
 
         self.count.fetch_add(new_point_count, Ordering::Release);
     }
+
+    fn take(&mut self) -> (usize, Vec<Series>) {
+        let result = self
+            .sb
+            .drain()
+            .map(|(ChannelDescriptor { name, tags }, points)| {
+                let channel = Channel { name };
+                let points_obj = Points {
+                    points_type: Some(points),
+                };
+                Series {
+                    channel: Some(channel),
+                    tags: tags
+                        .map(|tags| tags.into_iter().collect())
+                        .unwrap_or_default(),
+                    points: Some(points_obj),
+                }
+            })
+            .collect();
+        let result_count = self
+            .count
+            .fetch_update(Ordering::Release, Ordering::Acquire, |_| Some(0))
+            .unwrap();
+        (result_count, result)
+    }
 }
 
 impl PartialEq for SeriesBuffer {
@@ -198,28 +223,7 @@ impl SeriesBuffer {
             UNIX_EPOCH.elapsed().unwrap().as_nanos() as u64,
             Ordering::Release,
         );
-        let result = points
-            .sb
-            .drain()
-            .map(|(ChannelDescriptor { name, tags }, points)| {
-                let channel = Channel { name };
-                let points_obj = Points {
-                    points_type: Some(points),
-                };
-                Series {
-                    channel: Some(channel),
-                    tags: tags
-                        .map(|tags| tags.into_iter().collect())
-                        .unwrap_or_default(),
-                    points: Some(points_obj),
-                }
-            })
-            .collect();
-        let result_count = self
-            .count
-            .fetch_update(Ordering::Release, Ordering::Acquire, |_| Some(0))
-            .unwrap();
-        (result_count, result)
+        points.take()
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -1,31 +1,19 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use std::time::Instant;
-use std::time::UNIX_EPOCH;
 
 use conjure_object::BearerToken;
 use conjure_object::ResourceIdentifier;
-use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
-use nominal_api::tonic::io::nominal::scout::api::proto::points::PointsType;
-use nominal_api::tonic::io::nominal::scout::api::proto::ArrayPoints;
-use nominal_api::tonic::io::nominal::scout::api::proto::Channel;
 use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
-use nominal_api::tonic::io::nominal::scout::api::proto::Points;
-use nominal_api::tonic::io::nominal::scout::api::proto::Series;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequestNominal;
-use parking_lot::Condvar;
-use parking_lot::Mutex;
-use parking_lot::MutexGuard;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -39,6 +27,8 @@ use crate::consumer::NominalCoreConsumer;
 use crate::consumer::RequestConsumerWithFallback;
 use crate::consumer::WriteRequestConsumer;
 use crate::listener::LoggingListener;
+use crate::series_buffer::SeriesBuffer;
+use crate::series_buffer::SeriesBufferGuard;
 use crate::types::ChannelDescriptor;
 use crate::types::IntoPoints;
 use crate::types::IntoTimestamp;
@@ -492,233 +482,6 @@ impl NominalStringWriter<'_> {
             timestamp: Some(timestamp.into_timestamp()),
             value: value.into(),
         });
-    }
-}
-
-struct SeriesBuffer {
-    points: Mutex<HashMap<ChannelDescriptor, PointsType>>,
-    count: AtomicUsize,
-    flush_time: AtomicU64,
-    condvar: Condvar,
-    max_capacity: usize,
-}
-
-struct SeriesBufferGuard<'sb> {
-    sb: MutexGuard<'sb, HashMap<ChannelDescriptor, PointsType>>,
-    count: &'sb AtomicUsize,
-}
-
-impl SeriesBufferGuard<'_> {
-    fn extend(&mut self, channel_descriptor: &ChannelDescriptor, points: impl IntoPoints) {
-        let points = points.into_points();
-        let new_point_count = points.len();
-
-        if !self.sb.contains_key(channel_descriptor) {
-            self.sb.insert(channel_descriptor.clone(), points);
-        } else {
-            match (self.sb.get_mut(channel_descriptor).unwrap(), points) {
-                (PointsType::DoublePoints(existing), PointsType::DoublePoints(new)) => {
-                    existing.points.extend(new.points)
-                }
-                (PointsType::StringPoints(existing), PointsType::StringPoints(new)) => {
-                    existing.points.extend(new.points)
-                }
-                (PointsType::IntegerPoints(existing), PointsType::IntegerPoints(new)) => {
-                    existing.points.extend(new.points)
-                }
-                (
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::DoubleArrayPoints(existing)),
-                    }),
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::DoubleArrayPoints(new)),
-                    }),
-                ) => existing.points.extend(new.points),
-                (
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::StringArrayPoints(existing)),
-                    }),
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::StringArrayPoints(new)),
-                    }),
-                ) => existing.points.extend(new.points),
-                (
-                    PointsType::ArrayPoints(ArrayPoints { array_type: None }),
-                    PointsType::ArrayPoints(ArrayPoints { array_type: None }),
-                ) => {}
-                (PointsType::StructPoints(existing), PointsType::StructPoints(new)) => {
-                    existing.points.extend(new.points);
-                }
-                // this is hideous, but exhaustive matching is good to avoid future errors
-                (
-                    PointsType::DoublePoints(_),
-                    PointsType::IntegerPoints(_)
-                    | PointsType::StringPoints(_)
-                    | PointsType::ArrayPoints(_)
-                    | PointsType::StructPoints(_),
-                )
-                | (
-                    PointsType::StringPoints(_),
-                    PointsType::DoublePoints(_)
-                    | PointsType::IntegerPoints(_)
-                    | PointsType::ArrayPoints(_)
-                    | PointsType::StructPoints(_),
-                )
-                | (
-                    PointsType::IntegerPoints(_),
-                    PointsType::DoublePoints(_)
-                    | PointsType::StringPoints(_)
-                    | PointsType::ArrayPoints(_)
-                    | PointsType::StructPoints(_),
-                )
-                | (
-                    PointsType::ArrayPoints(_),
-                    PointsType::DoublePoints(_)
-                    | PointsType::StringPoints(_)
-                    | PointsType::IntegerPoints(_)
-                    | PointsType::StructPoints(_),
-                )
-                | (
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(_),
-                    }),
-                    PointsType::ArrayPoints(ArrayPoints { array_type: None }),
-                )
-                | (
-                    PointsType::ArrayPoints(ArrayPoints { array_type: None }),
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(_),
-                    }),
-                )
-                | (
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::DoubleArrayPoints(_)),
-                    }),
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::StringArrayPoints(_)),
-                    }),
-                )
-                | (
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::StringArrayPoints(_)),
-                    }),
-                    PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::DoubleArrayPoints(_)),
-                    }),
-                )
-                | (
-                    PointsType::StructPoints(_),
-                    PointsType::DoublePoints(_)
-                    | PointsType::StringPoints(_)
-                    | PointsType::IntegerPoints(_)
-                    | PointsType::ArrayPoints(_),
-                ) => {
-                    // todo: improve error
-                    panic!("mismatched types");
-                }
-            }
-        }
-
-        self.count.fetch_add(new_point_count, Ordering::Release);
-    }
-}
-
-impl PartialEq for SeriesBuffer {
-    fn eq(&self, other: &Self) -> bool {
-        self.flush_time.load(Ordering::Acquire) == other.flush_time.load(Ordering::Acquire)
-    }
-}
-
-impl PartialOrd for SeriesBuffer {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let flush_time = self.flush_time.load(Ordering::Acquire);
-        let other_flush_time = other.flush_time.load(Ordering::Acquire);
-        flush_time.partial_cmp(&other_flush_time)
-    }
-}
-
-impl SeriesBuffer {
-    fn new(capacity: usize) -> Self {
-        Self {
-            points: Mutex::new(HashMap::new()),
-            count: AtomicUsize::new(0),
-            flush_time: AtomicU64::new(0),
-            condvar: Condvar::new(),
-            max_capacity: capacity,
-        }
-    }
-
-    /// Checks if the buffer has enough capacity to add new points.
-    /// Note that the buffer can be larger than MAX_POINTS_PER_RECORD if a single batch of points
-    /// larger than MAX_POINTS_PER_RECORD is inserted while the buffer is empty. This avoids needing
-    /// to handle splitting batches of points across multiple requests.
-    fn has_capacity(&self, new_points_count: usize) -> bool {
-        let count = self.count.load(Ordering::Acquire);
-        count == 0 || count + new_points_count <= self.max_capacity
-    }
-
-    fn lock(&self) -> SeriesBufferGuard<'_> {
-        SeriesBufferGuard {
-            sb: self.points.lock(),
-            count: &self.count,
-        }
-    }
-
-    fn take(&self) -> (usize, Vec<Series>) {
-        let mut points = self.lock();
-        self.flush_time.store(
-            UNIX_EPOCH.elapsed().unwrap().as_nanos() as u64,
-            Ordering::Release,
-        );
-        let result = points
-            .sb
-            .drain()
-            .map(|(ChannelDescriptor { name, tags }, points)| {
-                let channel = Channel { name };
-                let points_obj = Points {
-                    points_type: Some(points),
-                };
-                Series {
-                    channel: Some(channel),
-                    tags: tags
-                        .map(|tags| tags.into_iter().collect())
-                        .unwrap_or_default(),
-                    points: Some(points_obj),
-                }
-            })
-            .collect();
-        let result_count = self
-            .count
-            .fetch_update(Ordering::Release, Ordering::Acquire, |_| Some(0))
-            .unwrap();
-        (result_count, result)
-    }
-
-    fn is_empty(&self) -> bool {
-        self.count() == 0
-    }
-
-    fn count(&self) -> usize {
-        self.count.load(Ordering::Acquire)
-    }
-
-    fn on_notify(&self, on_notify: impl FnOnce(SeriesBufferGuard)) {
-        let mut points_lock = self.points.lock();
-        // concurrency bug without this - the buffer could have been emptied since we
-        // checked the count, so this will wait forever & block any new points from entering
-        if !points_lock.is_empty() {
-            self.condvar.wait(&mut points_lock);
-        } else {
-            debug!("buffer emptied since last check, skipping condvar wait");
-        }
-        on_notify(SeriesBufferGuard {
-            sb: points_lock,
-            count: &self.count,
-        });
-    }
-
-    fn notify(&self) -> bool {
-        self.condvar.notify_one()
     }
 }
 

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -356,12 +356,12 @@ impl NominalDatasetStream {
 
         if self.primary_buffer.has_capacity(new_count) {
             debug!("adding {} points to primary buffer", new_count);
-            callback(self.primary_buffer.lock());
+            self.primary_buffer.with_lock(callback);
         } else if self.secondary_buffer.has_capacity(new_count) {
             // primary buffer is definitely full
             self.primary_handle.thread().unpark();
             debug!("adding {} points to secondary buffer", new_count);
-            callback(self.secondary_buffer.lock());
+            self.secondary_buffer.with_lock(callback);
         } else {
             let buf = if self.primary_buffer < self.secondary_buffer {
                 info!("waiting for primary buffer to flush to append {new_count} points...");

--- a/nominal-streaming/src/types.rs
+++ b/nominal-streaming/src/types.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use conjure_object::BearerToken;
 use nominal_api::api::rids::WorkspaceRid;
 use nominal_api::tonic::google::protobuf::Timestamp;
+use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
 use nominal_api::tonic::io::nominal::scout::api::proto::points::PointsType;
 use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoints;
@@ -115,6 +116,26 @@ impl IntoTimestamp for i64 {
         Timestamp {
             seconds: (self / NANOS_PER_SECOND),
             nanos: (self % NANOS_PER_SECOND) as i32,
+        }
+    }
+}
+
+pub trait PointsTypeExt {
+    fn len(&self) -> usize;
+}
+
+impl PointsTypeExt for PointsType {
+    fn len(&self) -> usize {
+        match self {
+            PointsType::DoublePoints(points) => points.points.len(),
+            PointsType::StringPoints(points) => points.points.len(),
+            PointsType::IntegerPoints(points) => points.points.len(),
+            PointsType::ArrayPoints(points) => match &points.array_type {
+                Some(ArrayType::DoubleArrayPoints(points)) => points.points.len(),
+                Some(ArrayType::StringArrayPoints(points)) => points.points.len(),
+                None => 0,
+            },
+            PointsType::StructPoints(points) => points.points.len(),
         }
     }
 }


### PR DESCRIPTION
This PR is an opinionated solution to #139 and is an extension of/alternative to #144 and #145. It details one approach to how data hiding can be enforced more rigorously.

I'm not sure how you all at Nominal prefer to stack PRs, so rather than opening six more PRs I simply stacked commits in a single PR. While this is less noisy for the repo, it can be a bit challenging to review. If you prefer a different workflow, let me know and I can accommodate.

If you like some of these concepts but not all, they can be extracted from the chain and (with some manipulation) landed independently.

The concepts are:
- extract implementation of `points_len()` into the `PointsTypeExt` trait for sharing
- move `SeriesBuffer` into a new module, `series_buffer.rs`
- move implementation of `take()` to `SeriesBufferGuard`
- add `SeriesBufferInner` type
- add `with_lock()` API to `SeriesBuffer` and `SeriesBufferInner`
- move `SeriesBufferInner` into inner scope for additional data hiding

I rather like the idea of the `with_lock()` API, which clearly exposes the lifetime of the mutex guard. This idea was borrowed from:
- [mutex::ScopedRawMutex::with_lock()](https://docs.rs/mutex/latest/mutex/trait.ScopedRawMutex.html#tymethod.with_lock)
- [mutex::BlockingMutex::with_lock()](https://docs.rs/mutex/latest/mutex/struct.BlockingMutex.html#method.with_lock)