### PR TITLE
fix: make py-nominal-streaming not build with cargo build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
 ]
 resolver = "2"
 
+# Require opt-in for building python bindings (should be built with maturin, not cargo)
+default-members = ["nominal-streaming"]
+
 [workspace.dependencies]
 apache-avro = { version = "0.17.0", features = ["snappy"] }
 async-channel = "2.5.0"


### PR DESCRIPTION
To build the py-nominal-streaming package, one must run commands using `uv`. From the `python.just` file in the repo root:

```
# Install all neessary python packages for building / running python code
install:
    @echo "Running 'install' for Python code"
    uv sync

# Build python code + rust bindings into wheel file
build:
    @echo "Running 'build' for py-nominal-streaming"
    uv build --package nominal-streaming

# Build python code + rust bindings into local dev mode
dev:
    @echo "Running 'dev' for py-nominal-streaming"
    uv run maturin develop --manifest-path py-nominal-streaming/Cargo.toml
```

Linting / formatting of the rust code within `py-nominal-streaming` are still linted / validated in the same way `just rust::fix`, `just rust::check`, etc.

If necessary, `cargo` commands may still be ran against `py-nominal-streaming` like `cargo build --package py-nominal-streaming`, though, this particular command is expected to fail most of the time.