### PR TITLE
feat: add support for uint64

### DIFF
--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -176,6 +176,8 @@ pub mod prelude {
     pub use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoints;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::StringPoints;
+    pub use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Point;
+    pub use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Points;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequest;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequestNominal;
 

--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -318,6 +318,10 @@ mod tests {
                 &ChannelDescriptor::with_tags("int", [("batch_id", batch.to_string())]),
                 ints,
             );
+            stream.enqueue(
+                &ChannelDescriptor::with_tags("uint64", [("batch_id", batch.to_string())]),
+                uints,
+            );
         }
 
         drop(stream); // wait for points to flush
@@ -326,7 +330,7 @@ mod tests {
 
         // validate that the requests were flushed based on the max_records value, not the
         // max request delay
-        assert_eq!(requests.len(), 15);
+        assert_eq!(requests.len(), 20);
 
         let r = requests
             .iter()
@@ -441,7 +445,7 @@ mod tests {
 
         let requests = test_consumer.requests.lock().unwrap();
 
-        assert_eq!(requests.len(), 15);
+        assert_eq!(requests.len(), 20);
 
         let r = requests
             .iter()

--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -285,6 +285,7 @@ mod tests {
             let mut doubles = Vec::new();
             let mut strings = Vec::new();
             let mut ints = Vec::new();
+            let mut uints = Vec::new();
             for i in 0..1000 {
                 let start_time = UNIX_EPOCH.elapsed().unwrap();
                 doubles.push(DoublePoint {
@@ -298,6 +299,10 @@ mod tests {
                 ints.push(IntegerPoint {
                     timestamp: Some(start_time.into_timestamp()),
                     value: i % 50,
+                });
+                uints.push(Uint64Point {
+                    timestamp: Some(start_time.into_timestamp()),
+                    value: (i % 50) as u64,
                 })
             }
 
@@ -341,6 +346,10 @@ mod tests {
             panic!("invalid int points type");
         };
 
+        let PointsType::Uint64Points(up) = r.get("uint64").unwrap() else {
+            panic!("invalid uint64 points type");
+        };
+
         let PointsType::StringPoints(sp) = r.get("string").unwrap() else {
             panic!("invalid string points type");
         };
@@ -349,6 +358,7 @@ mod tests {
         assert_eq!(dp.points.len(), 1000);
         assert_eq!(sp.points.len(), 1000);
         assert_eq!(ip.points.len(), 1000);
+        assert_eq!(up.points.len(), 1000);
     }
 
     #[test_log::test]
@@ -408,9 +418,11 @@ mod tests {
         let cd1 = ChannelDescriptor::new("double");
         let cd2 = ChannelDescriptor::new("string");
         let cd3 = ChannelDescriptor::new("int");
+        let cd4 = ChannelDescriptor::new("uint64");
         let mut double_writer = stream.double_writer(&cd1);
         let mut string_writer = stream.string_writer(&cd2);
         let mut integer_writer = stream.integer_writer(&cd3);
+        let mut uint64_writer = stream.uint64_writer(&cd4);
 
         for i in 0..5000 {
             let start_time = UNIX_EPOCH.elapsed().unwrap();
@@ -418,11 +430,13 @@ mod tests {
             double_writer.push(start_time, value as f64);
             string_writer.push(start_time, format!("{}", value));
             integer_writer.push(start_time, value);
+            uint64_writer.push(start_time, value as u64);
         }
 
         drop(double_writer);
         drop(string_writer);
         drop(integer_writer);
+        drop(uint64_writer);
         drop(stream);
 
         let requests = test_consumer.requests.lock().unwrap();
@@ -448,6 +462,10 @@ mod tests {
             panic!("invalid int points type");
         };
 
+        let PointsType::Uint64Points(up) = r.get("uint64").unwrap() else {
+            panic!("invalid uint64 points type");
+        };
+
         let PointsType::StringPoints(sp) = r.get("string").unwrap() else {
             panic!("invalid string points type");
         };
@@ -456,5 +474,6 @@ mod tests {
         assert_eq!(dp.points.len(), 1000);
         assert_eq!(sp.points.len(), 1000);
         assert_eq!(ip.points.len(), 1000);
+        assert_eq!(up.points.len(), 1000);
     }
 }

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -22,6 +22,7 @@ use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::Points;
 use nominal_api::tonic::io::nominal::scout::api::proto::Series;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
+use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Point;
 use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequestNominal;
 use parking_lot::Condvar;
 use parking_lot::Mutex;
@@ -475,6 +476,19 @@ pub struct NominalIntegerWriter<'ds> {
 impl NominalIntegerWriter<'_> {
     pub fn push(&mut self, timestamp: impl IntoTimestamp, value: i64) {
         self.writer.push_point(IntegerPoint {
+            timestamp: Some(timestamp.into_timestamp()),
+            value,
+        });
+    }
+}
+
+pub struct NominalUint64Writer<'ds> {
+    writer: NominalChannelWriter<'ds, Uint64Point>,
+}
+
+impl NominalUint64Writer<'_> {
+    pub fn push(&mut self, timestamp: impl IntoTimestamp, value: u64) {
+        self.writer.push_point(Uint64Point {
             timestamp: Some(timestamp.into_timestamp()),
             value,
         });

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -351,6 +351,15 @@ impl NominalDatasetStream {
         }
     }
 
+    pub fn uint64_writer<'a>(
+        &'a self,
+        channel_descriptor: &'a ChannelDescriptor,
+    ) -> NominalUint64Writer<'a> {
+        NominalUint64Writer {
+            writer: NominalChannelWriter::new(self, channel_descriptor),
+        }
+    }
+
     pub fn enqueue(&self, channel_descriptor: &ChannelDescriptor, new_points: impl IntoPoints) {
         let new_points = new_points.into_points();
         let new_count = points_len(&new_points);

--- a/nominal-streaming/src/types.rs
+++ b/nominal-streaming/src/types.rs
@@ -11,6 +11,8 @@ use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoints;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoints;
+use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Point;
+use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Points;
 
 const NANOS_PER_SECOND: i64 = 1_000_000_000;
 
@@ -85,6 +87,12 @@ impl IntoPoints for Vec<StringPoint> {
 impl IntoPoints for Vec<IntegerPoint> {
     fn into_points(self) -> PointsType {
         PointsType::IntegerPoints(IntegerPoints { points: self })
+    }
+}
+
+impl IntoPoints for Vec<Uint64Point> {
+    fn into_points(self) -> PointsType {
+        PointsType::Uint64Points(Uint64Points { points: self })
     }
 }
 


### PR DESCRIPTION
## Description

Now that Uint64 is supported with protobuf streaming in scout, adding support  for this in nominal-streaming.

## Test

Ran `cargo build`. Will test with another consuming library once changes are released.