### PR TITLE
feat: add StructPoints

### DIFF
--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -369,7 +369,7 @@ mod tests {
             panic!("invalid string points type");
         };
 
-        let PointsType::StructPoints(sp) = r.get("struct").unwrap() else {
+        let PointsType::StructPoints(stp) = r.get("struct").unwrap() else {
             panic!("invalid struct points type");
         };
 
@@ -378,7 +378,7 @@ mod tests {
         assert_eq!(sp.points.len(), 1000);
         assert_eq!(ip.points.len(), 1000);
         assert_eq!(up.points.len(), 1000);
-        assert_eq!(sp.points.len(), 1000);
+        assert_eq!(stp.points.len(), 1000);
     }
 
     #[test_log::test]
@@ -465,7 +465,7 @@ mod tests {
 
         let requests = test_consumer.requests.lock().unwrap();
 
-        assert_eq!(requests.len(), 20);
+        assert_eq!(requests.len(), 25);
 
         let r = requests
             .iter()
@@ -494,7 +494,7 @@ mod tests {
             panic!("invalid string points type");
         };
 
-        let PointsType::StructPoints(sp) = r.get("struct").unwrap() else {
+        let PointsType::StructPoints(stp) = r.get("struct").unwrap() else {
             panic!("invalid struct points type");
         };
 
@@ -503,6 +503,6 @@ mod tests {
         assert_eq!(sp.points.len(), 1000);
         assert_eq!(ip.points.len(), 1000);
         assert_eq!(up.points.len(), 1000);
-        assert_eq!(sp.points.len(), 1000);
+        assert_eq!(stp.points.len(), 1000);
     }
 }

--- a/nominal-streaming/src/types.rs
+++ b/nominal-streaming/src/types.rs
@@ -11,6 +11,8 @@ use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoints;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoints;
+use nominal_api::tonic::io::nominal::scout::api::proto::StructPoint;
+use nominal_api::tonic::io::nominal::scout::api::proto::StructPoints;
 use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Point;
 use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Points;
 
@@ -89,6 +91,13 @@ impl IntoPoints for Vec<IntegerPoint> {
         PointsType::IntegerPoints(IntegerPoints { points: self })
     }
 }
+
+impl IntoPoints for Vec<StructPoint> {
+    fn into_points(self) -> PointsType {
+        PointsType::StructPoints(StructPoints { points: self })
+    }
+}
+
 
 impl IntoPoints for Vec<Uint64Point> {
     fn into_points(self) -> PointsType {

--- a/nominal-streaming/src/types.rs
+++ b/nominal-streaming/src/types.rs
@@ -98,7 +98,6 @@ impl IntoPoints for Vec<StructPoint> {
     }
 }
 
-
 impl IntoPoints for Vec<Uint64Point> {
     fn into_points(self) -> PointsType {
         PointsType::Uint64Points(Uint64Points { points: self })


### PR DESCRIPTION
Fixes MDEV-45

## Description

This change adds StructPoints as a viable write object to the `nominal-streaming` library. Now that we have `StructPoints` in the protobuf library, we just need to add this as a type to streaming.

## Testing

I pointed `nominal-streaming-bench` to my local run of `nominal-streaming` and created a new test method which writes one struct to a test dataset.

```
let sample_json = r#"{
        "id": "12345",
        "name": "test_item",
        "value": 42.5,
        "active": true
    }"#;
```

This wrote to the "test_channel" channel in [this](https://app.gov.nominal.io/data-sources/ri.catalog.cerulean-staging.dataset.31dd0e5b-492c-4a6c-8376-dd5d3595b9aa) dataset.  Data shows up in a [workbook]( https://app.gov.nominal.io/workbooks/ri.scout.cerulean-staging.notebook.dcf22a12-9b56-47ae-b73c-7d0f57ee6964?sidebar=datascopes&tab=f3f6c92e-ccb3-485c-b5a9-1d6f2d84558f&dataScopeRid=ri.scout.cerulean-staging.asset.69021c09-744c-46c1-acea-0f70973371fa&ridType=asset&chartTimeStart=1735126844422.722.780&chartTimeEnd=1798172026409.122.503&streamingType=not-streaming&streamingWindow=30s). This verifies that we can stream structs end-end using `nominal-streaming`.