### PR TITLE
feat: support new streaming types in avro file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "snap",
+ "tempfile",
  "test-log",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ url = "2.5.8"
 
 # Test dependencies
 test-log = { version = "0.2.19", features = ["trace"] }
+tempfile = "3"
 
 # Allow workspace packages to access core package
 nominal-streaming = { path = "nominal-streaming" }

--- a/nominal-streaming/Cargo.toml
+++ b/nominal-streaming/Cargo.toml
@@ -37,3 +37,4 @@ url = { workspace = true }
 
 [dev-dependencies]
 test-log = { workspace = true }
+tempfile = { workspace = true }

--- a/nominal-streaming/src/consumer.rs
+++ b/nominal-streaming/src/consumer.rs
@@ -723,41 +723,119 @@ mod tests {
                     );
 
                 if let (Some(channel), Some(Value::Array(values))) = (channel, values) {
-                    assert!(!values.is_empty(), "Channel {} should have values", channel);
+                    assert_eq!(values.len(), 2, "Channel {} should have 2 values", channel);
 
-                    // Check the first value's union type
-                    if let Some(Value::Union(idx, inner)) = values.first() {
-                        match channel.as_str() {
-                            "doubles" => {
-                                assert_eq!(*idx, 0, "doubles should use union index 0");
-                                assert!(matches!(inner.as_ref(), Value::Double(_)));
-                            }
-                            "strings" => {
-                                assert_eq!(*idx, 1, "strings should use union index 1");
-                                assert!(matches!(inner.as_ref(), Value::String(_)));
-                            }
-                            "longs" => {
-                                assert_eq!(*idx, 2, "longs should use union index 2");
-                                assert!(matches!(inner.as_ref(), Value::Long(_)));
-                            }
-                            "double_arrays" => {
-                                assert_eq!(*idx, 3, "double_arrays should use union index 3");
-                                assert!(matches!(inner.as_ref(), Value::Record(_)));
-                            }
-                            "string_arrays" => {
-                                assert_eq!(*idx, 4, "string_arrays should use union index 4");
-                                assert!(matches!(inner.as_ref(), Value::Record(_)));
-                            }
-                            "structs" => {
-                                assert_eq!(*idx, 5, "structs should use union index 5");
-                                assert!(matches!(inner.as_ref(), Value::Record(_)));
-                            }
-                            "uint64s" => {
-                                assert_eq!(*idx, 2, "uint64s should use union index 2 (long)");
-                                assert!(matches!(inner.as_ref(), Value::Long(_)));
-                            }
-                            _ => panic!("Unexpected channel: {}", channel),
+                    match channel.as_str() {
+                        "doubles" => {
+                            assert_eq!(values[0], Value::Union(0, Box::new(Value::Double(1.5))));
+                            assert_eq!(values[1], Value::Union(0, Box::new(Value::Double(2.5))));
                         }
+                        "strings" => {
+                            assert_eq!(
+                                values[0],
+                                Value::Union(1, Box::new(Value::String("hello".to_string())))
+                            );
+                            assert_eq!(
+                                values[1],
+                                Value::Union(1, Box::new(Value::String("world".to_string())))
+                            );
+                        }
+                        "longs" => {
+                            assert_eq!(values[0], Value::Union(2, Box::new(Value::Long(42))));
+                            assert_eq!(values[1], Value::Union(2, Box::new(Value::Long(-100))));
+                        }
+                        "double_arrays" => {
+                            assert_eq!(
+                                values[0],
+                                Value::Union(
+                                    3,
+                                    Box::new(Value::Record(vec![(
+                                        "items".to_string(),
+                                        Value::Array(vec![
+                                            Value::Double(1.0),
+                                            Value::Double(2.0),
+                                            Value::Double(3.0)
+                                        ])
+                                    )]))
+                                )
+                            );
+                            assert_eq!(
+                                values[1],
+                                Value::Union(
+                                    3,
+                                    Box::new(Value::Record(vec![(
+                                        "items".to_string(),
+                                        Value::Array(vec![Value::Double(4.0), Value::Double(5.0)])
+                                    )]))
+                                )
+                            );
+                        }
+                        "string_arrays" => {
+                            assert_eq!(
+                                values[0],
+                                Value::Union(
+                                    4,
+                                    Box::new(Value::Record(vec![(
+                                        "items".to_string(),
+                                        Value::Array(vec![
+                                            Value::String("a".to_string()),
+                                            Value::String("b".to_string())
+                                        ])
+                                    )]))
+                                )
+                            );
+                            assert_eq!(
+                                values[1],
+                                Value::Union(
+                                    4,
+                                    Box::new(Value::Record(vec![(
+                                        "items".to_string(),
+                                        Value::Array(vec![
+                                            Value::String("c".to_string()),
+                                            Value::String("d".to_string()),
+                                            Value::String("e".to_string())
+                                        ])
+                                    )]))
+                                )
+                            );
+                        }
+                        "structs" => {
+                            assert_eq!(
+                                values[0],
+                                Value::Union(
+                                    5,
+                                    Box::new(Value::Record(vec![(
+                                        "json".to_string(),
+                                        Value::String(r#"{"key": "value"}"#.to_string())
+                                    )]))
+                                )
+                            );
+                            assert_eq!(
+                                values[1],
+                                Value::Union(
+                                    5,
+                                    Box::new(Value::Record(vec![(
+                                        "json".to_string(),
+                                        Value::String(r#"{"count": 42}"#.to_string())
+                                    )]))
+                                )
+                            );
+                        }
+                        "uint64s" => {
+                            // u64::MAX as i64 is -1, 12345678901234567890u64 as i64 is negative
+                            assert_eq!(
+                                values[0],
+                                Value::Union(2, Box::new(Value::Long(u64::MAX as i64)))
+                            );
+                            assert_eq!(
+                                values[1],
+                                Value::Union(
+                                    2,
+                                    Box::new(Value::Long(12345678901234567890u64 as i64))
+                                )
+                            );
+                        }
+                        _ => panic!("Unexpected channel: {}", channel),
                     }
                 }
             }

--- a/nominal-streaming/src/consumer.rs
+++ b/nominal-streaming/src/consumer.rs
@@ -121,13 +121,13 @@ pub static CORE_SCHEMA_STR: &str = r#"{
           "name": "values",
           "type": {"type": "array", "items": [
               "double",
-              "long",
               "string",
+              "long",
               {"type": "record", "name": "DoubleArray", "fields": [{"name": "items", "type": {"type": "array", "items": "double"}}]},
               {"type": "record", "name": "StringArray", "fields": [{"name": "items", "type": {"type": "array", "items": "string"}}]},
               {"type": "record", "name": "JsonStruct", "fields": [{"name": "json", "type": "string"}]}
           ]},
-          "doc": "Array of values. Can be doubles, longs, strings, arrays, JSON structs, or unsigned 64-bit integers"
+          "doc": "Array of values. Can be doubles, longs, strings, arrays, or JSON structs"
       },
       {
           "name": "tags",
@@ -247,7 +247,7 @@ fn points_to_avro(points: Option<&Points>) -> (Vec<Value>, Vec<Value>) {
             .map(|point| {
                 (
                     convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                    Value::Union(2, Box::new(Value::String(point.value.clone()))),
+                    Value::Union(1, Box::new(Value::String(point.value.clone()))),
                 )
             })
             .collect(),
@@ -256,7 +256,7 @@ fn points_to_avro(points: Option<&Points>) -> (Vec<Value>, Vec<Value>) {
             .map(|point| {
                 (
                     convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                    Value::Union(1, Box::new(Value::Long(point.value))),
+                    Value::Union(2, Box::new(Value::Long(point.value))),
                 )
             })
             .collect(),
@@ -312,7 +312,7 @@ fn points_to_avro(points: Option<&Points>) -> (Vec<Value>, Vec<Value>) {
             .map(|point| {
                 (
                     convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                    Value::Union(1, Box::new(Value::Long(point.value as i64))),
+                    Value::Union(2, Box::new(Value::Long(point.value as i64))),
                 )
             })
             .collect(),
@@ -732,13 +732,13 @@ mod tests {
                                 assert_eq!(*idx, 0, "doubles should use union index 0");
                                 assert!(matches!(inner.as_ref(), Value::Double(_)));
                             }
-                            "longs" => {
-                                assert_eq!(*idx, 1, "longs should use union index 1");
-                                assert!(matches!(inner.as_ref(), Value::Long(_)));
-                            }
                             "strings" => {
-                                assert_eq!(*idx, 2, "strings should use union index 2");
+                                assert_eq!(*idx, 1, "strings should use union index 1");
                                 assert!(matches!(inner.as_ref(), Value::String(_)));
+                            }
+                            "longs" => {
+                                assert_eq!(*idx, 2, "longs should use union index 2");
+                                assert!(matches!(inner.as_ref(), Value::Long(_)));
                             }
                             "double_arrays" => {
                                 assert_eq!(*idx, 3, "double_arrays should use union index 3");
@@ -753,7 +753,7 @@ mod tests {
                                 assert!(matches!(inner.as_ref(), Value::Record(_)));
                             }
                             "uint64s" => {
-                                assert_eq!(*idx, 1, "uint64s should use union index 1 (long)");
+                                assert_eq!(*idx, 2, "uint64s should use union index 2 (long)");
                                 assert!(matches!(inner.as_ref(), Value::Long(_)));
                             }
                             _ => panic!("Unexpected channel: {}", channel),

--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -64,13 +64,13 @@ let value: f64 = 123;
 writer.push(start_time, value);
 ```
 
-Here, we are enquing data onto Channel 1, with tags "name" and "batch".
+Here, we are enqueing data onto Channel 1, with tags "name" and "batch".
 These are, of course, just examples, and you can choose your own.
 
 ## Example: streaming from memory to Nominal Core, with file fallback
 
 This is the typical scenario where we want to stream some values from memory into a [Nominal Dataset](https://docs.nominal.io/core/sdk/python-client/streaming/overview#streaming-data-to-a-dataset).
-If the upload fails (say because of network errors), we'd like to instead send the data to an AVRO file.
+If the upload fails (say because of network errors), we'd like to instead send the data to an Avro file. Note that the Avro spec does not support uint64 values, so those will be stored as signed int64 values.
 
 Note that we set up the async [Tokio runtime](https://tokio.rs/), since that is required by the underlying [`NominalCoreConsumer`](https://docs.rs/nominal-streaming/latest/nominal_streaming/consumer/struct.NominalCoreConsumer.html).
 

--- a/py-nominal-streaming/src/nominal_dataset_stream.rs
+++ b/py-nominal-streaming/src/nominal_dataset_stream.rs
@@ -172,7 +172,7 @@ impl PyNominalDatasetStream {
         mut slf: PyRefMut<'py, Self>,
         path: PathBuf,
     ) -> PyResult<PyRefMut<'py, Self>> {
-        slf.builder.targets.file_target = Some(FileTarget { path: path });
+        slf.builder.targets.file_target = Some(FileTarget { path });
         Ok(slf)
     }
 


### PR DESCRIPTION
adds new columns to the avro schema for int/uint, struct, and array types. this ensures data is not lost when streaming.

this format isn't yet supported by the nominal core backend, but keen to merge this first to avoid accidental data loss due to the missing types in the existing schema.

note that `uint64` will be cast into `int64` as avro does not support uints. this will be fixed in a future non-avro streaming format.