### PR TITLE
fix: skip signal handler registration in worker threads

### DIFF
--- a/py-nominal-streaming/examples/test_worker_thread.py
+++ b/py-nominal-streaming/examples/test_worker_thread.py
@@ -13,7 +13,6 @@ import threading
 import time
 
 from nominal.core import NominalClient
-
 from nominal_streaming import NominalDatasetStream, PyNominalStreamOpts
 
 logger = logging.getLogger(__name__)

--- a/py-nominal-streaming/examples/test_worker_thread.py
+++ b/py-nominal-streaming/examples/test_worker_thread.py
@@ -1,0 +1,94 @@
+"""Test that streaming works from a worker thread (not the main thread).
+
+This test verifies the fix for the signal handler threading issue.
+Before the fix, this would raise:
+    ValueError: signal only works in main thread of the main interpreter
+
+Usage:
+    uv run python py-nominal-streaming/examples/test_worker_thread.py
+"""
+
+import logging
+import threading
+import time
+
+from nominal.core import NominalClient
+
+from nominal_streaming import NominalDatasetStream, PyNominalStreamOpts
+
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    num_rows = 100_000
+    num_batches = 1000
+    client = NominalClient.from_profile("staging")
+    dataset = client.create_dataset("py-nominal-streaming threading test")
+
+    auth_header = client._clients.auth_header.split()[-1]
+    base_api_url = client._clients.authentication._uri
+
+    stream = (
+        NominalDatasetStream(
+            auth_header=auth_header,
+            opts=PyNominalStreamOpts(
+                num_upload_workers=16,
+                max_buffered_requests=4,
+                num_runtime_workers=20,
+                max_points_per_batch=100_000,
+                base_api_url=base_api_url,
+            ),
+        )
+        .enable_logging("info")
+        .with_core_consumer(dataset.rid)
+    )
+    logger.info("Streaming to dataset %s", dataset.nominal_url)
+
+    error_holder: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            start_time = time.time()
+            offset = 1.0 / 1600
+            curr_offset = 0.0
+            values = [1.3 + idx for idx in range(num_rows)]
+
+            with stream:
+                for batch_idx in range(num_batches):
+                    batch_build_start = time.time()
+                    timestamps = [int((start_time + curr_offset + offset * idx) * 1e9) for idx in range(num_rows)]
+                    curr_offset += num_rows * offset
+                    batch_build_end = time.time()
+                    stream.enqueue_batch("worker_thread_channel", timestamps, values)
+                    batch_enqueue_end = time.time()
+
+                    logger.info(
+                        "Batch took %f seconds; build took %f seconds; enqueue took %f seconds",
+                        batch_enqueue_end - batch_build_start,
+                        batch_build_end - batch_build_start,
+                        batch_enqueue_end - batch_build_end,
+                    )
+                enqueue_end = time.time()
+            end_time = time.time()
+
+            logger.info(
+                "Overall: %f seconds to enqueue; %f seconds to flush, %f seconds overall",
+                enqueue_end - start_time,
+                end_time - enqueue_end,
+                end_time - start_time,
+            )
+        except Exception as e:
+            error_holder.append(e)
+
+    thread = threading.Thread(target=worker, name="nominal-write-thread-0")
+    thread.start()
+    thread.join()
+
+    if error_holder:
+        dataset.archive()
+        logger.info("Archived dataset %s", dataset.nominal_url)
+        raise error_holder[0]
+
+    dataset.archive()
+    logger.info("Archived dataset %s", dataset.nominal_url)
+    logger.info("SUCCESS: Worker thread streaming completed without error")

--- a/py-nominal-streaming/examples/test_worker_thread.py
+++ b/py-nominal-streaming/examples/test_worker_thread.py
@@ -27,26 +27,27 @@ if __name__ == "__main__":
     auth_header = client._clients.auth_header.split()[-1]
     base_api_url = client._clients.authentication._uri
 
-    stream = (
-        NominalDatasetStream(
-            auth_header=auth_header,
-            opts=PyNominalStreamOpts(
-                num_upload_workers=16,
-                max_buffered_requests=4,
-                num_runtime_workers=20,
-                max_points_per_batch=100_000,
-                base_api_url=base_api_url,
-            ),
-        )
-        .enable_logging("info")
-        .with_core_consumer(dataset.rid)
-    )
     logger.info("Streaming to dataset %s", dataset.nominal_url)
 
     error_holder: list[Exception] = []
 
     def worker() -> None:
         try:
+            stream = (
+                NominalDatasetStream(
+                    auth_header=auth_header,
+                    opts=PyNominalStreamOpts(
+                        num_upload_workers=16,
+                        max_buffered_requests=4,
+                        num_runtime_workers=20,
+                        max_points_per_batch=100_000,
+                        base_api_url=base_api_url,
+                    ),
+                )
+                .enable_logging("info")
+                .with_core_consumer(dataset.rid)
+            )
+
             start_time = time.time()
             offset = 1.0 / 1600
             curr_offset = 0.0


### PR DESCRIPTION
# Summary

Python's signal.signal() can only be called from the main thread. Previously, using NominalDatasetStream from a worker thread would raise:
    ValueError: signal only works in main thread of the main interpreter

This change detects if we're running in the main thread and only registers the SIGINT handler there. In worker threads, the stream still functions normally but Ctrl+C won't trigger fast cancellation - graceful shutdown will be used instead when the context manager exits.

Also adds a separate _opened flag to track stream state, decoupling it from the signal handler state.

# Testing
A new test script was written, which attempts to run the same test conditions as the previous test script except from a worker thread. This test was confirmed to be able to complete nominally via the staging API. The existing test case was also run successfully against staging, including ^C interrupt, as regression testing.


# Background

Customer was running into the following error when running the streaming from a worker thread:

`INFO nominal_streaming.nominal_dataset_stream Opening underlying stream
INFO nominal_streaming.nominal_dataset_stream Installing sigint handler
Exception in thread nominal-write-thread-0:
Traceback (most recent call last):
  File "/home/vscode/.local/share/uv/python/cpython-3.12.10-linux-x86_64-gnu/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/home/vscode/.local/share/uv/python/cpython-3.12.10-linux-x86_64-gnu/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/workspace/src/pipeline/data_funnel.py", line 59, in _sink_write
    sink.write(batch)
  File "/workspace/src/telemetry/sink/nominal.py", line 158, in write
    with self.dataset.get_write_stream(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.12/site-packages/nominal_streaming/nominal_dataset_stream.py", line 211, in __enter__
    return self.open()
           ^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.12/site-packages/nominal_streaming/nominal_dataset_stream.py", line 202, in open
    signal.signal(signal.SIGINT, _on_sigint)
  File "/home/vscode/.local/share/uv/python/cpython-3.12.10-linux-x86_64-gnu/lib/python3.12/signal.py", line 58, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: signal only works in main thread of the main interpreter`

Customer says they are not able to easily run from the main thread due to their service architecture 

> running the streaming in the main thread of our service is not really an option we'd like to consider because it would fundamentally change the service architecture

They have implemented a workaround of commenting out the relevant signal handling code. This PR seeks to make the changes necessary for them to be able to use the library without code changes.