### PR TITLE
feat: switch to writeNominalColumnarBatches endpoint

### DIFF
--- a/nominal-streaming/src/client.rs
+++ b/nominal-streaming/src/client.rs
@@ -11,7 +11,6 @@ use conjure_http::private::header::CONTENT_TYPE;
 use conjure_http::private::Request;
 use conjure_http::private::Response;
 use conjure_object::BearerToken;
-use conjure_object::ResourceIdentifier;
 use conjure_runtime_rustls_platform_verifier::conjure_runtime::Agent;
 use conjure_runtime_rustls_platform_verifier::conjure_runtime::BodyWriter;
 use conjure_runtime_rustls_platform_verifier::conjure_runtime::Client;
@@ -19,7 +18,6 @@ use conjure_runtime_rustls_platform_verifier::conjure_runtime::Idempotency;
 use conjure_runtime_rustls_platform_verifier::conjure_runtime::UserAgent;
 use conjure_runtime_rustls_platform_verifier::PlatformVerifierClient;
 use conjure_runtime_rustls_platform_verifier::ResponseBody;
-use nominal_api::api::rids::NominalDataSourceOrDatasetRid;
 use nominal_api::api::rids::WorkspaceRid;
 use nominal_api::ingest::api::IngestServiceAsyncClient;
 use nominal_api::upload::api::UploadServiceAsyncClient;
@@ -145,10 +143,9 @@ pub fn async_conjure_client(
 
 pub type WriteRequest<'a> = Request<AsyncRequestBody<'a, BodyWriter>>;
 
-pub fn encode_request<'a, 'b>(
+pub fn encode_request<'b>(
     write_request_bytes: Vec<u8>,
-    api_key: &'a BearerToken,
-    data_source_rid: &'a ResourceIdentifier,
+    api_key: &BearerToken,
 ) -> std::io::Result<WriteRequest<'b>> {
     let mut encoder = FrameEncoder::new(Vec::with_capacity(write_request_bytes.len()));
 
@@ -164,10 +161,7 @@ pub fn encode_request<'a, 'b>(
 
     *request.method_mut() = conjure_http::private::http::Method::POST;
     let mut path = conjure_http::private::UriBuilder::new();
-    path.push_literal("/storage/writer/v1/nominal");
-
-    let nominal_data_source_or_dataset_rid = NominalDataSourceOrDatasetRid(data_source_rid.clone());
-    path.push_path_parameter(&nominal_data_source_or_dataset_rid);
+    path.push_literal("/storage/writer/v1/nominal-columnar");
 
     *request.uri_mut() = path.build();
     conjure_http::private::encode_header_auth(&mut request, api_key);
@@ -177,8 +171,8 @@ pub fn encode_request<'a, 'b>(
         .insert(conjure_http::client::Endpoint::new(
             "NominalChannelWriterService",
             None,
-            "writeNominalBatches",
-            "/storage/writer/v1/nominal/{dataSourceRid}",
+            "writeNominalColumnarBatches",
+            "/storage/writer/v1/nominal-columnar",
         ));
     Ok(request)
 }

--- a/nominal-streaming/src/consumer.rs
+++ b/nominal-streaming/src/consumer.rs
@@ -8,18 +8,13 @@ use std::sync::LazyLock;
 use apache_avro::types::Record;
 use apache_avro::types::Value;
 use conjure_object::ResourceIdentifier;
-use nominal_api::tonic::google::protobuf::Timestamp;
-use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
-use nominal_api::tonic::io::nominal::scout::api::proto::points::PointsType;
-use nominal_api::tonic::io::nominal::scout::api::proto::ArrayPoints;
-use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoints;
-use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoints;
-use nominal_api::tonic::io::nominal::scout::api::proto::Points;
-use nominal_api::tonic::io::nominal::scout::api::proto::Series;
-use nominal_api::tonic::io::nominal::scout::api::proto::StringPoints;
-use nominal_api::tonic::io::nominal::scout::api::proto::StructPoints;
-use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Points;
-use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequestNominal;
+use nominal_api::tonic::nominal::direct_channel_writer::v2::WriteBatchesRequest;
+use nominal_api::tonic::nominal::direct_channel_writer::v2::{
+    self as columnar, DoublePoints, IntPoints, LogPoints, StringPoints, StructPoints,
+    Uint64Points,
+};
+use nominal_api::tonic::nominal::direct_channel_writer::v2::array_points::ArrayType as ColumnarArrayType;
+use nominal_api::tonic::nominal::types::time::Timestamp as NominalTimestamp;
 use parking_lot::Mutex;
 use prost::Message;
 use tracing::warn;
@@ -46,7 +41,7 @@ pub enum ConsumerError {
 pub type ConsumerResult<T> = Result<T, ConsumerError>;
 
 pub trait WriteRequestConsumer: Send + Sync + Debug {
-    fn consume(&self, request: &WriteRequestNominal) -> ConsumerResult<()>;
+    fn consume(&self, request: &WriteBatchesRequest) -> ConsumerResult<()>;
 }
 
 #[derive(Clone)]
@@ -83,13 +78,15 @@ impl<T: AuthProvider> Debug for NominalCoreConsumer<T> {
 }
 
 impl<T: AuthProvider + 'static> WriteRequestConsumer for NominalCoreConsumer<T> {
-    fn consume(&self, request: &WriteRequestNominal) -> ConsumerResult<()> {
+    fn consume(&self, request: &WriteBatchesRequest) -> ConsumerResult<()> {
         let token = self
             .auth_provider
             .token()
             .ok_or(ConsumerError::MissingTokenError)?;
-        let write_request =
-            client::encode_request(request.encode_to_vec(), &token, &self.data_source_rid)?;
+        // Set the data_source_rid in the proto body before encoding
+        let mut request_with_rid = request.clone();
+        request_with_rid.data_source_rid = self.data_source_rid.to_string();
+        let write_request = client::encode_request(request_with_rid.encode_to_vec(), &token)?;
         self.handle.block_on(async {
             self.client
                 .send(write_request)
@@ -193,24 +190,17 @@ impl AvroFileConsumer {
         })
     }
 
-    fn append_series(&self, series: &[Series]) -> ConsumerResult<()> {
+    fn append_batches(&self, batches: &[columnar::RecordsBatch]) -> ConsumerResult<()> {
         let mut records: Vec<Record> = Vec::new();
-        for series in series {
-            let (timestamps, values) = points_to_avro(series.points.as_ref());
+        for batch in batches {
+            let (timestamps, values) = columnar_points_to_avro(batch.points.as_ref());
 
             let mut record = Record::new(&CORE_AVRO_SCHEMA).expect("Failed to create Avro record");
 
-            record.put(
-                "channel",
-                series
-                    .channel
-                    .as_ref()
-                    .map(|c| c.name.clone())
-                    .unwrap_or("values".to_string()),
-            );
+            record.put("channel", batch.channel.clone());
             record.put("timestamps", Value::Array(timestamps));
             record.put("values", Value::Array(values));
-            record.put("tags", series.tags.clone());
+            record.put("tags", batch.tags.clone());
 
             records.push(record);
         }
@@ -224,108 +214,104 @@ impl AvroFileConsumer {
     }
 }
 
-fn points_to_avro(points: Option<&Points>) -> (Vec<Value>, Vec<Value>) {
-    let Some(Points {
-        points_type: Some(points),
-    }) = points
-    else {
+fn convert_nominal_timestamp_to_nanoseconds(timestamp: &NominalTimestamp) -> Value {
+    let seconds = timestamp.seconds.unwrap_or(0);
+    let nanos = timestamp.nanos.unwrap_or(0);
+    Value::Long(seconds * 1_000_000_000 + nanos)
+}
+
+fn columnar_points_to_avro(
+    points: Option<&columnar::Points>,
+) -> (Vec<Value>, Vec<Value>) {
+    let Some(points) = points else {
         return (Vec::new(), Vec::new());
     };
 
-    match points {
-        PointsType::DoublePoints(DoublePoints { points }) => points
-            .iter()
-            .map(|point| {
-                (
-                    convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                    Value::Union(0, Box::new(Value::Double(point.value))),
-                )
-            })
-            .collect(),
-        PointsType::StringPoints(StringPoints { points }) => points
-            .iter()
-            .map(|point| {
-                (
-                    convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                    Value::Union(1, Box::new(Value::String(point.value.clone()))),
-                )
-            })
-            .collect(),
-        PointsType::IntegerPoints(IntegerPoints { points }) => points
-            .iter()
-            .map(|point| {
-                (
-                    convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                    Value::Union(2, Box::new(Value::Long(point.value))),
-                )
-            })
-            .collect(),
-        PointsType::ArrayPoints(ArrayPoints { array_type }) => match array_type {
-            Some(ArrayType::DoubleArrayPoints(points)) => points
-                .points
-                .iter()
-                .map(|point| {
-                    let array_values: Vec<Value> =
-                        point.value.iter().map(|v| Value::Double(*v)).collect();
-                    let record =
-                        Value::Record(vec![("items".to_string(), Value::Array(array_values))]);
-                    (
-                        convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                        Value::Union(3, Box::new(record)),
-                    )
-                })
-                .collect(),
-            Some(ArrayType::StringArrayPoints(points)) => points
-                .points
-                .iter()
-                .map(|point| {
-                    let array_values: Vec<Value> = point
-                        .value
-                        .iter()
-                        .map(|v| Value::String(v.clone()))
-                        .collect();
-                    let record =
-                        Value::Record(vec![("items".to_string(), Value::Array(array_values))]);
-                    (
-                        convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                        Value::Union(4, Box::new(record)),
-                    )
-                })
-                .collect(),
-            None => (Vec::new(), Vec::new()),
-        },
-        PointsType::StructPoints(StructPoints { points }) => points
-            .iter()
-            .map(|point| {
-                let record = Value::Record(vec![(
-                    "json".to_string(),
-                    Value::String(point.json_string.clone()),
-                )]);
-                (
-                    convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                    Value::Union(5, Box::new(record)),
-                )
-            })
-            .collect(),
-        PointsType::Uint64Points(Uint64Points { points }) => points
-            .iter()
-            .map(|point| {
-                (
-                    convert_timestamp_to_nanoseconds(point.timestamp.unwrap()),
-                    Value::Union(2, Box::new(Value::Long(point.value as i64))),
-                )
-            })
-            .collect(),
-    }
-}
+    let timestamps: Vec<Value> = points
+        .timestamps
+        .iter()
+        .map(convert_nominal_timestamp_to_nanoseconds)
+        .collect();
 
-fn convert_timestamp_to_nanoseconds(timestamp: Timestamp) -> Value {
-    Value::Long(timestamp.seconds * 1_000_000_000 + timestamp.nanos as i64)
+    let values: Vec<Value> = match &points.points {
+        Some(columnar::points::Points::DoublePoints(DoublePoints { points })) => points
+            .iter()
+            .map(|v| Value::Union(0, Box::new(Value::Double(*v))))
+            .collect(),
+        Some(columnar::points::Points::StringPoints(StringPoints { points })) => points
+            .iter()
+            .map(|v| Value::Union(1, Box::new(Value::String(v.clone()))))
+            .collect(),
+        Some(columnar::points::Points::IntPoints(IntPoints { points })) => points
+            .iter()
+            .map(|v| Value::Union(2, Box::new(Value::Long(*v))))
+            .collect(),
+        Some(columnar::points::Points::ArrayPoints(columnar::ArrayPoints { array_type })) => {
+            match array_type {
+                Some(ColumnarArrayType::DoubleArrayPoints(dap)) => dap
+                    .points
+                    .iter()
+                    .map(|point| {
+                        let array_values: Vec<Value> =
+                            point.value.iter().map(|v| Value::Double(*v)).collect();
+                        let record = Value::Record(vec![(
+                            "items".to_string(),
+                            Value::Array(array_values),
+                        )]);
+                        Value::Union(3, Box::new(record))
+                    })
+                    .collect(),
+                Some(ColumnarArrayType::StringArrayPoints(sap)) => sap
+                    .points
+                    .iter()
+                    .map(|point| {
+                        let array_values: Vec<Value> = point
+                            .value
+                            .iter()
+                            .map(|v: &String| Value::String(v.clone()))
+                            .collect();
+                        let record = Value::Record(vec![(
+                            "items".to_string(),
+                            Value::Array(array_values),
+                        )]);
+                        Value::Union(4, Box::new(record))
+                    })
+                    .collect(),
+                None => Vec::new(),
+            }
+        }
+        Some(columnar::points::Points::StructPoints(StructPoints { points })) => points
+            .iter()
+            .map(|v| {
+                let record =
+                    Value::Record(vec![("json".to_string(), Value::String(v.clone()))]);
+                Value::Union(5, Box::new(record))
+            })
+            .collect(),
+        Some(columnar::points::Points::Uint64Points(Uint64Points { points })) => points
+            .iter()
+            .map(|v| Value::Union(2, Box::new(Value::Long(*v as i64))))
+            .collect(),
+        Some(columnar::points::Points::LogPoints(LogPoints { points })) => points
+            .iter()
+            .map(|p| {
+                let msg = p
+                    .value
+                    .as_ref()
+                    .map(|v| v.message.clone())
+                    .unwrap_or_default();
+                Value::Union(1, Box::new(Value::String(msg)))
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+
+    (timestamps, values)
 }
 
 impl WriteRequestConsumer for AvroFileConsumer {
-    fn consume(&self, request: &WriteRequestNominal) -> ConsumerResult<()> {
-        self.append_series(&request.series)?;
+    fn consume(&self, request: &WriteBatchesRequest) -> ConsumerResult<()> {
+        self.append_batches(&request.batches)?;
         Ok(())
     }
 }
@@ -388,7 +374,7 @@ where
     P: WriteRequestConsumer + Send + Sync,
     S: WriteRequestConsumer + Send + Sync,
 {
-    fn consume(&self, request: &WriteRequestNominal) -> ConsumerResult<()> {
+    fn consume(&self, request: &WriteBatchesRequest) -> ConsumerResult<()> {
         let primary_result = self.primary.consume(request);
         let secondary_result = self.secondary.consume(request);
         if let Err(e) = &primary_result {
@@ -408,7 +394,7 @@ where
     P: WriteRequestConsumer + Send + Sync,
     F: WriteRequestConsumer + Send + Sync,
 {
-    fn consume(&self, request: &WriteRequestNominal) -> ConsumerResult<()> {
+    fn consume(&self, request: &WriteBatchesRequest) -> ConsumerResult<()> {
         if let Err(e) = self.primary.consume(request) {
             warn!("Sending request to primary consumer failed. Attempting fallback.");
             let fallback_result = self.fallback.consume(request);
@@ -448,7 +434,7 @@ impl<C> WriteRequestConsumer for ListeningWriteRequestConsumer<C>
 where
     C: WriteRequestConsumer + Send + Sync,
 {
-    fn consume(&self, request: &WriteRequestNominal) -> ConsumerResult<()> {
+    fn consume(&self, request: &WriteBatchesRequest) -> ConsumerResult<()> {
         match self.consumer.consume(request) {
             Ok(_) => {
                 self.listeners.on_success(request);
@@ -466,28 +452,28 @@ where
 mod tests {
     use std::collections::HashMap;
 
-    use apache_avro::Reader;
-    use nominal_api::tonic::google::protobuf::Timestamp;
-    use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
-    use nominal_api::tonic::io::nominal::scout::api::proto::Channel;
-    use nominal_api::tonic::io::nominal::scout::api::proto::DoubleArrayPoint;
-    use nominal_api::tonic::io::nominal::scout::api::proto::StringArrayPoint;
+    use nominal_api::tonic::nominal::direct_channel_writer::v2::{
+        self as columnar, DoubleArrayPoint, DoubleArrayPoints, StringArrayPoint,
+        StringArrayPoints,
+    };
+    use nominal_api::tonic::nominal::types::time::Timestamp as NominalTimestamp;
     use tempfile::NamedTempFile;
+
+    use apache_avro::Reader;
 
     use super::*;
 
-    fn make_timestamp(secs: i64, nanos: i32) -> Option<Timestamp> {
-        Some(Timestamp {
-            seconds: secs,
-            nanos,
-        })
+    fn make_timestamp(secs: i64, nanos: i64) -> NominalTimestamp {
+        NominalTimestamp {
+            seconds: Some(secs),
+            nanos: Some(nanos),
+            picos: None,
+        }
     }
 
-    fn make_series(name: &str, points: Points) -> Series {
-        Series {
-            channel: Some(Channel {
-                name: name.to_string(),
-            }),
+    fn make_batch(name: &str, points: columnar::Points) -> columnar::RecordsBatch {
+        columnar::RecordsBatch {
+            channel: name.to_string(),
             tags: HashMap::new(),
             points: Some(points),
         }
@@ -502,155 +488,112 @@ mod tests {
         {
             let consumer = AvroFileConsumer::new_with_full_path(&path).unwrap();
 
-            // Create series with each type
-            let double_series = make_series(
+            let double_batch = make_batch(
                 "doubles",
-                Points {
-                    points_type: Some(PointsType::DoublePoints(DoublePoints {
-                        points: vec![
-                            nominal_api::tonic::io::nominal::scout::api::proto::DoublePoint {
-                                timestamp: make_timestamp(1000, 0),
-                                value: 1.5,
-                            },
-                            nominal_api::tonic::io::nominal::scout::api::proto::DoublePoint {
-                                timestamp: make_timestamp(1001, 0),
-                                value: 2.5,
-                            },
-                        ],
+                columnar::Points {
+                    timestamps: vec![make_timestamp(1000, 0), make_timestamp(1001, 0)],
+                    points: Some(columnar::points::Points::DoublePoints(DoublePoints {
+                        points: vec![1.5, 2.5],
                     })),
                 },
             );
 
-            let long_series = make_series(
+            let int_batch = make_batch(
                 "longs",
-                Points {
-                    points_type: Some(PointsType::IntegerPoints(IntegerPoints {
-                        points: vec![
-                            nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint {
-                                timestamp: make_timestamp(1000, 0),
-                                value: 42,
-                            },
-                            nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint {
-                                timestamp: make_timestamp(1001, 0),
-                                value: -100,
-                            },
-                        ],
+                columnar::Points {
+                    timestamps: vec![make_timestamp(1000, 0), make_timestamp(1001, 0)],
+                    points: Some(columnar::points::Points::IntPoints(IntPoints {
+                        points: vec![42, -100],
                     })),
                 },
             );
 
-            let string_series = make_series(
+            let string_batch = make_batch(
                 "strings",
-                Points {
-                    points_type: Some(PointsType::StringPoints(StringPoints {
-                        points: vec![
-                            nominal_api::tonic::io::nominal::scout::api::proto::StringPoint {
-                                timestamp: make_timestamp(1000, 0),
-                                value: "hello".to_string(),
-                            },
-                            nominal_api::tonic::io::nominal::scout::api::proto::StringPoint {
-                                timestamp: make_timestamp(1001, 0),
-                                value: "world".to_string(),
-                            },
-                        ],
+                columnar::Points {
+                    timestamps: vec![make_timestamp(1000, 0), make_timestamp(1001, 0)],
+                    points: Some(columnar::points::Points::StringPoints(StringPoints {
+                        points: vec!["hello".to_string(), "world".to_string()],
                     })),
                 },
             );
 
-            let double_array_series = make_series(
+            let double_array_batch = make_batch(
                 "double_arrays",
-                Points {
-                    points_type: Some(PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::DoubleArrayPoints(
-                            nominal_api::tonic::io::nominal::scout::api::proto::DoubleArrayPoints {
-                                points: vec![
-                                    DoubleArrayPoint {
-                                        timestamp: make_timestamp(1000, 0),
-                                        value: vec![1.0, 2.0, 3.0],
-                                    },
-                                    DoubleArrayPoint {
-                                        timestamp: make_timestamp(1001, 0),
-                                        value: vec![4.0, 5.0],
-                                    },
-                                ],
-                            },
-                        )),
+                columnar::Points {
+                    timestamps: vec![make_timestamp(1000, 0), make_timestamp(1001, 0)],
+                    points: Some(columnar::points::Points::ArrayPoints(columnar::ArrayPoints {
+                        array_type: Some(ColumnarArrayType::DoubleArrayPoints(DoubleArrayPoints {
+                            points: vec![
+                                DoubleArrayPoint {
+                                    value: vec![1.0, 2.0, 3.0],
+                                },
+                                DoubleArrayPoint {
+                                    value: vec![4.0, 5.0],
+                                },
+                            ],
+                        })),
                     })),
                 },
             );
 
-            let string_array_series = make_series(
+            let string_array_batch = make_batch(
                 "string_arrays",
-                Points {
-                    points_type: Some(PointsType::ArrayPoints(ArrayPoints {
-                        array_type: Some(ArrayType::StringArrayPoints(
-                            nominal_api::tonic::io::nominal::scout::api::proto::StringArrayPoints {
-                                points: vec![
-                                    StringArrayPoint {
-                                        timestamp: make_timestamp(1000, 0),
-                                        value: vec!["a".to_string(), "b".to_string()],
-                                    },
-                                    StringArrayPoint {
-                                        timestamp: make_timestamp(1001, 0),
-                                        value: vec![
-                                            "c".to_string(),
-                                            "d".to_string(),
-                                            "e".to_string(),
-                                        ],
-                                    },
-                                ],
-                            },
-                        )),
+                columnar::Points {
+                    timestamps: vec![make_timestamp(1000, 0), make_timestamp(1001, 0)],
+                    points: Some(columnar::points::Points::ArrayPoints(columnar::ArrayPoints {
+                        array_type: Some(ColumnarArrayType::StringArrayPoints(StringArrayPoints {
+                            points: vec![
+                                StringArrayPoint {
+                                    value: vec!["a".to_string(), "b".to_string()],
+                                },
+                                StringArrayPoint {
+                                    value: vec![
+                                        "c".to_string(),
+                                        "d".to_string(),
+                                        "e".to_string(),
+                                    ],
+                                },
+                            ],
+                        })),
                     })),
                 },
             );
 
-            let struct_series = make_series(
+            let struct_batch = make_batch(
                 "structs",
-                Points {
-                    points_type: Some(PointsType::StructPoints(StructPoints {
+                columnar::Points {
+                    timestamps: vec![make_timestamp(1000, 0), make_timestamp(1001, 0)],
+                    points: Some(columnar::points::Points::StructPoints(StructPoints {
                         points: vec![
-                            nominal_api::tonic::io::nominal::scout::api::proto::StructPoint {
-                                timestamp: make_timestamp(1000, 0),
-                                json_string: r#"{"key": "value"}"#.to_string(),
-                            },
-                            nominal_api::tonic::io::nominal::scout::api::proto::StructPoint {
-                                timestamp: make_timestamp(1001, 0),
-                                json_string: r#"{"count": 42}"#.to_string(),
-                            },
+                            r#"{"key": "value"}"#.to_string(),
+                            r#"{"count": 42}"#.to_string(),
                         ],
                     })),
                 },
             );
 
-            let uint64_series = make_series(
+            let uint64_batch = make_batch(
                 "uint64s",
-                Points {
-                    points_type: Some(PointsType::Uint64Points(Uint64Points {
-                        points: vec![
-                            nominal_api::tonic::io::nominal::scout::api::proto::Uint64Point {
-                                timestamp: make_timestamp(1000, 0),
-                                value: u64::MAX,
-                            },
-                            nominal_api::tonic::io::nominal::scout::api::proto::Uint64Point {
-                                timestamp: make_timestamp(1001, 0),
-                                value: 12345678901234567890,
-                            },
-                        ],
+                columnar::Points {
+                    timestamps: vec![make_timestamp(1000, 0), make_timestamp(1001, 0)],
+                    points: Some(columnar::points::Points::Uint64Points(Uint64Points {
+                        points: vec![u64::MAX, 12345678901234567890],
                     })),
                 },
             );
 
-            let request = WriteRequestNominal {
-                series: vec![
-                    double_series,
-                    long_series,
-                    string_series,
-                    double_array_series,
-                    string_array_series,
-                    struct_series,
-                    uint64_series,
+            let request = WriteBatchesRequest {
+                batches: vec![
+                    double_batch,
+                    int_batch,
+                    string_batch,
+                    double_array_batch,
+                    string_array_batch,
+                    struct_batch,
+                    uint64_batch,
                 ],
+                data_source_rid: String::new(),
             };
 
             consumer.consume(&request).unwrap();
@@ -664,7 +607,7 @@ mod tests {
         let reader = Reader::new(file).unwrap();
 
         let records: Vec<_> = reader.map(|r| r.unwrap()).collect();
-        assert_eq!(records.len(), 7, "Expected 7 series records");
+        assert_eq!(records.len(), 7, "Expected 7 batch records");
 
         // Verify each record has the expected channel name and value types
         let channels: Vec<String> = records

--- a/nominal-streaming/src/listener.rs
+++ b/nominal-streaming/src/listener.rs
@@ -3,23 +3,23 @@ use std::fmt::Debug;
 use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 
-use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequestNominal;
+use nominal_api::tonic::nominal::direct_channel_writer::v2::WriteBatchesRequest;
 use tracing::error;
 
 pub trait NominalStreamListener: Send + Sync + Debug + RefUnwindSafe {
-    fn on_error(&self, error: &dyn Error, request: &WriteRequestNominal);
+    fn on_error(&self, error: &dyn Error, request: &WriteBatchesRequest);
 
-    fn on_success(&self, _request: &WriteRequestNominal) {}
+    fn on_success(&self, _request: &WriteBatchesRequest) {}
 }
 
 impl NominalStreamListener for Vec<Arc<dyn NominalStreamListener>> {
-    fn on_error(&self, error: &dyn Error, request: &WriteRequestNominal) {
+    fn on_error(&self, error: &dyn Error, request: &WriteBatchesRequest) {
         for listener in self {
             listener.on_error(error, request);
         }
     }
 
-    fn on_success(&self, request: &WriteRequestNominal) {
+    fn on_success(&self, request: &WriteBatchesRequest) {
         for listener in self {
             listener.on_success(request);
         }
@@ -30,9 +30,9 @@ impl NominalStreamListener for Vec<Arc<dyn NominalStreamListener>> {
 pub struct LoggingListener;
 
 impl NominalStreamListener for LoggingListener {
-    fn on_error(&self, error: &dyn Error, request: &WriteRequestNominal) {
-        let len = request.series.len();
-        let message = format!("Failed to consume request with {len} series");
+    fn on_error(&self, error: &dyn Error, request: &WriteBatchesRequest) {
+        let len = request.batches.len();
+        let message = format!("Failed to consume request with {len} batches");
         error!("{message}: {error}");
     }
 }

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -892,9 +892,7 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
 }
 
 /// Convert an old google.protobuf.Timestamp to the nominal.types.time.Timestamp.
-fn to_nominal_timestamp(
-    ts: &nominal_api::tonic::google::protobuf::Timestamp,
-) -> NominalTimestamp {
+fn to_nominal_timestamp(ts: &nominal_api::tonic::google::protobuf::Timestamp) -> NominalTimestamp {
     NominalTimestamp {
         seconds: Some(ts.seconds),
         nanos: Some(ts.nanos as i64),
@@ -949,9 +947,9 @@ fn points_type_to_columnar(points_type: PointsType) -> columnar::Points {
             }
             columnar::Points {
                 timestamps,
-                points: Some(columnar::points::Points::IntPoints(
-                    columnar::IntPoints { points: values },
-                )),
+                points: Some(columnar::points::Points::IntPoints(columnar::IntPoints {
+                    points: values,
+                })),
             }
         }
         PointsType::Uint64Points(up) => {
@@ -1000,11 +998,9 @@ fn points_type_to_columnar(points_type: PointsType) -> columnar::Points {
                     timestamps,
                     points: Some(columnar::points::Points::ArrayPoints(
                         columnar::ArrayPoints {
-                            array_type: Some(
-                                columnar::array_points::ArrayType::DoubleArrayPoints(
-                                    columnar::DoubleArrayPoints { points: values },
-                                ),
-                            ),
+                            array_type: Some(columnar::array_points::ArrayType::DoubleArrayPoints(
+                                columnar::DoubleArrayPoints { points: values },
+                            )),
                         },
                     )),
                 }
@@ -1022,11 +1018,9 @@ fn points_type_to_columnar(points_type: PointsType) -> columnar::Points {
                     timestamps,
                     points: Some(columnar::points::Points::ArrayPoints(
                         columnar::ArrayPoints {
-                            array_type: Some(
-                                columnar::array_points::ArrayType::StringArrayPoints(
-                                    columnar::StringArrayPoints { points: values },
-                                ),
-                            ),
+                            array_type: Some(columnar::array_points::ArrayType::StringArrayPoints(
+                                columnar::StringArrayPoints { points: values },
+                            )),
                         },
                     )),
                 }

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -16,15 +16,14 @@ use conjure_object::ResourceIdentifier;
 use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
 use nominal_api::tonic::io::nominal::scout::api::proto::points::PointsType;
 use nominal_api::tonic::io::nominal::scout::api::proto::ArrayPoints;
-use nominal_api::tonic::io::nominal::scout::api::proto::Channel;
 use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
-use nominal_api::tonic::io::nominal::scout::api::proto::Points;
-use nominal_api::tonic::io::nominal::scout::api::proto::Series;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::StructPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Point;
-use nominal_api::tonic::io::nominal::scout::api::proto::WriteRequestNominal;
+use nominal_api::tonic::nominal::direct_channel_writer::v2 as columnar;
+use nominal_api::tonic::nominal::direct_channel_writer::v2::WriteBatchesRequest;
+use nominal_api::tonic::nominal::types::time::Timestamp as NominalTimestamp;
 use parking_lot::Condvar;
 use parking_lot::Mutex;
 use parking_lot::MutexGuard;
@@ -263,7 +262,7 @@ impl NominalDatasetStream {
         let secondary_buffer = Arc::new(SeriesBuffer::new(opts.max_points_per_record));
 
         let (request_tx, request_rx) =
-            crossbeam_channel::bounded::<(WriteRequestNominal, usize)>(opts.max_buffered_requests);
+            crossbeam_channel::bounded::<(WriteBatchesRequest, usize)>(opts.max_buffered_requests);
 
         let running = Arc::new(AtomicBool::new(true));
         let unflushed_points = Arc::new(AtomicUsize::new(0));
@@ -728,7 +727,7 @@ impl SeriesBuffer {
         }
     }
 
-    fn take(&self) -> (usize, Vec<Series>) {
+    fn take(&self) -> (usize, Vec<columnar::RecordsBatch>) {
         let mut points = self.lock();
         self.flush_time.store(
             UNIX_EPOCH.elapsed().unwrap().as_nanos() as u64,
@@ -737,17 +736,14 @@ impl SeriesBuffer {
         let result = points
             .sb
             .drain()
-            .map(|(ChannelDescriptor { name, tags }, points)| {
-                let channel = Channel { name };
-                let points_obj = Points {
-                    points_type: Some(points),
-                };
-                Series {
-                    channel: Some(channel),
+            .map(|(ChannelDescriptor { name, tags }, points_type)| {
+                let columnar_points = points_type_to_columnar(points_type);
+                columnar::RecordsBatch {
+                    channel: name,
                     tags: tags
                         .map(|tags| tags.into_iter().collect())
                         .unwrap_or_default(),
-                    points: Some(points_obj),
+                    points: Some(columnar_points),
                 }
             })
             .collect();
@@ -789,7 +785,7 @@ impl SeriesBuffer {
 fn batch_processor(
     running: Arc<AtomicBool>,
     points_buffer: Arc<SeriesBuffer>,
-    request_chan: crossbeam_channel::Sender<(WriteRequestNominal, usize)>,
+    request_chan: crossbeam_channel::Sender<(WriteBatchesRequest, usize)>,
     max_request_delay: Duration,
 ) {
     loop {
@@ -805,13 +801,17 @@ fn batch_processor(
             }
             continue;
         }
-        let (point_count, series) = points_buffer.take();
+        let (point_count, batches) = points_buffer.take();
 
         if points_buffer.notify() {
             debug!("notified one waiting thread after clearing points buffer");
         }
 
-        let write_request = WriteRequestNominal { series };
+        // data_source_rid is set by the consumer (NominalCoreConsumer) before encoding
+        let write_request = WriteBatchesRequest {
+            batches,
+            data_source_rid: String::new(),
+        };
 
         if request_chan.is_full() {
             debug!("ready to queue request but request channel is full");
@@ -850,7 +850,7 @@ impl Drop for NominalDatasetStream {
 fn request_dispatcher<C: WriteRequestConsumer + 'static>(
     running: Arc<AtomicBool>,
     unflushed_points: Arc<AtomicUsize>,
-    request_rx: crossbeam_channel::Receiver<(WriteRequestNominal, usize)>,
+    request_rx: crossbeam_channel::Receiver<(WriteBatchesRequest, usize)>,
     consumer: Arc<C>,
 ) {
     let mut total_request_time = 0;
@@ -889,6 +889,154 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
         "request dispatcher thread exiting. total request time: {}",
         total_request_time
     );
+}
+
+/// Convert an old google.protobuf.Timestamp to the nominal.types.time.Timestamp.
+fn to_nominal_timestamp(
+    ts: &nominal_api::tonic::google::protobuf::Timestamp,
+) -> NominalTimestamp {
+    NominalTimestamp {
+        seconds: Some(ts.seconds),
+        nanos: Some(ts.nanos as i64),
+        picos: None,
+    }
+}
+
+/// Convert row-oriented PointsType (with per-point timestamps) to columnar Points
+/// (separate timestamp array + packed value array).
+fn points_type_to_columnar(points_type: PointsType) -> columnar::Points {
+    match points_type {
+        PointsType::DoublePoints(dp) => {
+            let mut timestamps = Vec::with_capacity(dp.points.len());
+            let mut values = Vec::with_capacity(dp.points.len());
+            for point in dp.points {
+                if let Some(ts) = &point.timestamp {
+                    timestamps.push(to_nominal_timestamp(ts));
+                }
+                values.push(point.value);
+            }
+            columnar::Points {
+                timestamps,
+                points: Some(columnar::points::Points::DoublePoints(
+                    columnar::DoublePoints { points: values },
+                )),
+            }
+        }
+        PointsType::StringPoints(sp) => {
+            let mut timestamps = Vec::with_capacity(sp.points.len());
+            let mut values = Vec::with_capacity(sp.points.len());
+            for point in sp.points {
+                if let Some(ts) = &point.timestamp {
+                    timestamps.push(to_nominal_timestamp(ts));
+                }
+                values.push(point.value);
+            }
+            columnar::Points {
+                timestamps,
+                points: Some(columnar::points::Points::StringPoints(
+                    columnar::StringPoints { points: values },
+                )),
+            }
+        }
+        PointsType::IntegerPoints(ip) => {
+            let mut timestamps = Vec::with_capacity(ip.points.len());
+            let mut values = Vec::with_capacity(ip.points.len());
+            for point in ip.points {
+                if let Some(ts) = &point.timestamp {
+                    timestamps.push(to_nominal_timestamp(ts));
+                }
+                values.push(point.value);
+            }
+            columnar::Points {
+                timestamps,
+                points: Some(columnar::points::Points::IntPoints(
+                    columnar::IntPoints { points: values },
+                )),
+            }
+        }
+        PointsType::Uint64Points(up) => {
+            let mut timestamps = Vec::with_capacity(up.points.len());
+            let mut values = Vec::with_capacity(up.points.len());
+            for point in up.points {
+                if let Some(ts) = &point.timestamp {
+                    timestamps.push(to_nominal_timestamp(ts));
+                }
+                values.push(point.value);
+            }
+            columnar::Points {
+                timestamps,
+                points: Some(columnar::points::Points::Uint64Points(
+                    columnar::Uint64Points { points: values },
+                )),
+            }
+        }
+        PointsType::StructPoints(stp) => {
+            let mut timestamps = Vec::with_capacity(stp.points.len());
+            let mut values = Vec::with_capacity(stp.points.len());
+            for point in stp.points {
+                if let Some(ts) = &point.timestamp {
+                    timestamps.push(to_nominal_timestamp(ts));
+                }
+                values.push(point.json_string);
+            }
+            columnar::Points {
+                timestamps,
+                points: Some(columnar::points::Points::StructPoints(
+                    columnar::StructPoints { points: values },
+                )),
+            }
+        }
+        PointsType::ArrayPoints(ArrayPoints { array_type }) => match array_type {
+            Some(ArrayType::DoubleArrayPoints(dap)) => {
+                let mut timestamps = Vec::with_capacity(dap.points.len());
+                let mut values = Vec::with_capacity(dap.points.len());
+                for point in dap.points {
+                    if let Some(ts) = &point.timestamp {
+                        timestamps.push(to_nominal_timestamp(ts));
+                    }
+                    values.push(columnar::DoubleArrayPoint { value: point.value });
+                }
+                columnar::Points {
+                    timestamps,
+                    points: Some(columnar::points::Points::ArrayPoints(
+                        columnar::ArrayPoints {
+                            array_type: Some(
+                                columnar::array_points::ArrayType::DoubleArrayPoints(
+                                    columnar::DoubleArrayPoints { points: values },
+                                ),
+                            ),
+                        },
+                    )),
+                }
+            }
+            Some(ArrayType::StringArrayPoints(sap)) => {
+                let mut timestamps = Vec::with_capacity(sap.points.len());
+                let mut values = Vec::with_capacity(sap.points.len());
+                for point in sap.points {
+                    if let Some(ts) = &point.timestamp {
+                        timestamps.push(to_nominal_timestamp(ts));
+                    }
+                    values.push(columnar::StringArrayPoint { value: point.value });
+                }
+                columnar::Points {
+                    timestamps,
+                    points: Some(columnar::points::Points::ArrayPoints(
+                        columnar::ArrayPoints {
+                            array_type: Some(
+                                columnar::array_points::ArrayType::StringArrayPoints(
+                                    columnar::StringArrayPoints { points: values },
+                                ),
+                            ),
+                        },
+                    )),
+                }
+            }
+            None => columnar::Points {
+                timestamps: Vec::new(),
+                points: None,
+            },
+        },
+    }
 }
 
 fn points_len(points_type: &PointsType) -> usize {


### PR DESCRIPTION
## Summary
- Switches from the row-oriented `writeNominalBatches` endpoint (`POST /storage/writer/v1/nominal/{dataSourceRid}`) to the new columnar `writeNominalColumnarBatches` endpoint (`POST /storage/writer/v1/nominal-columnar`)
- The columnar format stores timestamps and values as separate packed arrays per channel, enabling better compression and lower latency
- `data_source_rid` is now included in the protobuf body rather than as a URL path parameter
- Internal buffer still uses row-oriented point types; conversion to columnar happens at serialization time in `SeriesBuffer::take()`

## Changes
- **`client.rs`**: Updated endpoint path, removed `data_source_rid` path parameter
- **`consumer.rs`**: `WriteRequestConsumer` trait now operates on `WriteBatchesRequest` (columnar); `NominalCoreConsumer` sets `data_source_rid` in the proto body before encoding; `AvroFileConsumer` updated for columnar format
- **`stream.rs`**: Added `points_type_to_columnar()` conversion function; `SeriesBuffer::take()` now produces `Vec<RecordsBatch>`; `batch_processor()` creates `WriteBatchesRequest`
- **`listener.rs`**: `NominalStreamListener` trait uses `WriteBatchesRequest`
- **`lib.rs`**: Updated prelude exports and all integration tests for columnar format

## Test plan
- [x] All 6 existing tests pass with columnar format
- [x] `cargo clippy` is clean
- [ ] Manual integration testing against staging/production environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)