### PR TITLE
refactor: make channel writers own ChannelDescriptor

### DIFF
--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -56,7 +56,7 @@ let channel_descriptor = ChannelDescriptor::with_tags(
     "channel_1", [("experiment_id", "123")]
 );
 
-let mut writer = stream.double_writer(&channel_descriptor);
+let mut writer = stream.double_writer(channel_descriptor);
 
 // Stream single data point
 let start_time = UNIX_EPOCH.elapsed().unwrap();
@@ -115,7 +115,7 @@ async fn async_main() {
 
     let channel_descriptor = ChannelDescriptor::with_tags("channel_1", [("experiment_id", "123")]);
 
-    let mut writer = stream.double_writer(&channel_descriptor);
+    let mut writer = stream.double_writer(channel_descriptor);
 
     // Generate and upload 100,000 data points
     for i in 0..100_000 {
@@ -386,7 +386,7 @@ mod tests {
         let (test_consumer, stream) = create_test_stream();
 
         let cd = ChannelDescriptor::new("channel_1");
-        let mut writer = stream.double_writer(&cd);
+        let mut writer = stream.double_writer(cd);
 
         for i in 0..5000 {
             let start_time = UNIX_EPOCH.elapsed().unwrap();
@@ -415,7 +415,7 @@ mod tests {
         let (test_consumer, stream) = create_test_stream();
 
         let cd = ChannelDescriptor::new("channel_1");
-        let mut writer = stream.double_writer(&cd);
+        let mut writer = stream.double_writer(cd);
 
         writer.push(UNIX_EPOCH.elapsed().unwrap(), 1.0);
         thread::sleep(Duration::from_millis(101));
@@ -440,11 +440,11 @@ mod tests {
         let cd3 = ChannelDescriptor::new("int");
         let cd4 = ChannelDescriptor::new("uint64");
         let cd5 = ChannelDescriptor::new("struct");
-        let mut double_writer = stream.double_writer(&cd1);
-        let mut string_writer = stream.string_writer(&cd2);
-        let mut integer_writer = stream.integer_writer(&cd3);
-        let mut uint64_writer = stream.uint64_writer(&cd4);
-        let mut struct_writer = stream.struct_writer(&cd5);
+        let mut double_writer = stream.double_writer(cd1);
+        let mut string_writer = stream.string_writer(cd2);
+        let mut integer_writer = stream.integer_writer(cd3);
+        let mut uint64_writer = stream.uint64_writer(cd4);
+        let mut struct_writer = stream.struct_writer(cd5);
 
         for i in 0..5000 {
             let start_time = UNIX_EPOCH.elapsed().unwrap();

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -325,46 +325,34 @@ impl NominalDatasetStream {
         }
     }
 
-    pub fn double_writer<'a>(
-        &'a self,
-        channel_descriptor: &'a ChannelDescriptor,
-    ) -> NominalDoubleWriter<'a> {
+    pub fn double_writer(&self, channel_descriptor: ChannelDescriptor) -> NominalDoubleWriter<'_> {
         NominalDoubleWriter {
             writer: NominalChannelWriter::new(self, channel_descriptor),
         }
     }
 
-    pub fn string_writer<'a>(
-        &'a self,
-        channel_descriptor: &'a ChannelDescriptor,
-    ) -> NominalStringWriter<'a> {
+    pub fn string_writer(&self, channel_descriptor: ChannelDescriptor) -> NominalStringWriter<'_> {
         NominalStringWriter {
             writer: NominalChannelWriter::new(self, channel_descriptor),
         }
     }
 
-    pub fn integer_writer<'a>(
-        &'a self,
-        channel_descriptor: &'a ChannelDescriptor,
-    ) -> NominalIntegerWriter<'a> {
+    pub fn integer_writer(
+        &self,
+        channel_descriptor: ChannelDescriptor,
+    ) -> NominalIntegerWriter<'_> {
         NominalIntegerWriter {
             writer: NominalChannelWriter::new(self, channel_descriptor),
         }
     }
 
-    pub fn uint64_writer<'a>(
-        &'a self,
-        channel_descriptor: &'a ChannelDescriptor,
-    ) -> NominalUint64Writer<'a> {
+    pub fn uint64_writer(&self, channel_descriptor: ChannelDescriptor) -> NominalUint64Writer<'_> {
         NominalUint64Writer {
             writer: NominalChannelWriter::new(self, channel_descriptor),
         }
     }
 
-    pub fn struct_writer<'a>(
-        &'a self,
-        channel_descriptor: &'a ChannelDescriptor,
-    ) -> NominalStructWriter<'a> {
+    pub fn struct_writer(&self, channel_descriptor: ChannelDescriptor) -> NominalStructWriter<'_> {
         NominalStructWriter {
             writer: NominalChannelWriter::new(self, channel_descriptor),
         }
@@ -410,7 +398,7 @@ pub struct NominalChannelWriter<'ds, T>
 where
     Vec<T>: IntoPoints,
 {
-    channel: &'ds ChannelDescriptor,
+    channel: ChannelDescriptor,
     stream: &'ds NominalDatasetStream,
     last_flushed_at: Instant,
     unflushed: Vec<T>,
@@ -420,10 +408,10 @@ impl<T> NominalChannelWriter<'_, T>
 where
     Vec<T>: IntoPoints,
 {
-    fn new<'ds>(
-        stream: &'ds NominalDatasetStream,
-        channel: &'ds ChannelDescriptor,
-    ) -> NominalChannelWriter<'ds, T> {
+    fn new(
+        stream: &NominalDatasetStream,
+        channel: ChannelDescriptor,
+    ) -> NominalChannelWriter<'_, T> {
         NominalChannelWriter {
             channel,
             stream,
@@ -458,7 +446,7 @@ where
         );
         self.stream.when_capacity(self.unflushed.len(), |mut buf| {
             let to_flush: Vec<T> = self.unflushed.drain(..).collect();
-            buf.extend(self.channel, to_flush);
+            buf.extend(&self.channel, to_flush);
             self.last_flushed_at = Instant::now();
         })
     }


### PR DESCRIPTION
## Summary
- Changed `NominalChannelWriter` to own `ChannelDescriptor` instead of borrowing it via `&'ds ChannelDescriptor`
- Updated all writer factory methods (`double_writer`, `string_writer`, `integer_writer`, `uint64_writer`, `struct_writer`) to take `ChannelDescriptor` by value
- Updated doc examples and tests to pass owned descriptors

This simplifies the lifetime requirements — callers no longer need to keep the descriptor alive for the duration of the writer. Since `ChannelDescriptor` is `Clone`, callers that need to reuse a descriptor can clone it.

**⚠️ this is technically a breaking change for consumers, although a relatively minor one. we warn in docs.rs that breaking changes are still possible, and given the low blast-radius here, we're comfortable making this change due to improved ergonomics**

## Test plan
- [x] All 6 existing tests pass
- [x] Doc-tests compile