### PR TITLE
feat: allow streaming structs and arrays from python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Python: `NominalDatasetStream.enqueue_struct`, `enqueue_float_array`, and `enqueue_string_array` for single-point struct and array values.
+- Rust: `NominalDatasetStream::double_array_writer` and `string_array_writer` symmetric with existing `double_writer` / `string_writer`.
+- Rust: `IntoPoints` impls for `Vec<DoubleArrayPoint>` and `Vec<StringArrayPoint>`.
+- Rust: prelude re-exports for `ArrayPoints`, `ArrayType`, `DoubleArrayPoint`, `DoubleArrayPoints`, `StringArrayPoint`, `StringArrayPoints`.
+
 ## [0.8.1](https://github.com/nominal-io/nominal-streaming/compare/v0.8.0...v0.8.1) - 2026-04-15
 
 ### Other

--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -169,11 +169,17 @@ pub mod prelude {
     pub use conjure_object::BearerToken;
     pub use conjure_object::ResourceIdentifier;
     pub use nominal_api::tonic::google::protobuf::Timestamp;
+    pub use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::points::PointsType;
+    pub use nominal_api::tonic::io::nominal::scout::api::proto::ArrayPoints;
+    pub use nominal_api::tonic::io::nominal::scout::api::proto::DoubleArrayPoint;
+    pub use nominal_api::tonic::io::nominal::scout::api::proto::DoubleArrayPoints;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoint;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoints;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoints;
+    pub use nominal_api::tonic::io::nominal::scout::api::proto::StringArrayPoint;
+    pub use nominal_api::tonic::io::nominal::scout::api::proto::StringArrayPoints;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::StringPoints;
     pub use nominal_api::tonic::io::nominal::scout::api::proto::StructPoint;
@@ -202,6 +208,8 @@ mod tests {
     use std::time::Duration;
     use std::time::UNIX_EPOCH;
 
+    use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
+    use nominal_api::tonic::io::nominal::scout::api::proto::ArrayPoints;
     use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
 
     use crate::client::PRODUCTION_API_URL;
@@ -289,6 +297,8 @@ mod tests {
             let mut structs = Vec::new();
             let mut ints = Vec::new();
             let mut uints = Vec::new();
+            let mut double_arrays = Vec::new();
+            let mut string_arrays = Vec::new();
             for i in 0..1000 {
                 let start_time = UNIX_EPOCH.elapsed().unwrap();
                 doubles.push(DoublePoint {
@@ -301,7 +311,7 @@ mod tests {
                 });
                 structs.push(StructPoint {
                     timestamp: Some(start_time.into_timestamp()),
-                    json_string: format!("{}", i % 50),
+                    json_string: format!("{{\"v\":{}}}", i % 50),
                 });
                 ints.push(IntegerPoint {
                     timestamp: Some(start_time.into_timestamp()),
@@ -310,7 +320,15 @@ mod tests {
                 uints.push(Uint64Point {
                     timestamp: Some(start_time.into_timestamp()),
                     value: (i % 50) as u64,
-                })
+                });
+                double_arrays.push(DoubleArrayPoint {
+                    timestamp: Some(start_time.into_timestamp()),
+                    value: vec![(i % 50) as f64, ((i + 1) % 50) as f64],
+                });
+                string_arrays.push(StringArrayPoint {
+                    timestamp: Some(start_time.into_timestamp()),
+                    value: vec![format!("{}", i % 50)],
+                });
             }
 
             stream.enqueue(
@@ -333,6 +351,14 @@ mod tests {
                 &ChannelDescriptor::with_tags("uint64", [("batch_id", batch.to_string())]),
                 uints,
             );
+            stream.enqueue(
+                &ChannelDescriptor::with_tags("double_array", [("batch_id", batch.to_string())]),
+                double_arrays,
+            );
+            stream.enqueue(
+                &ChannelDescriptor::with_tags("string_array", [("batch_id", batch.to_string())]),
+                string_arrays,
+            );
         }
 
         drop(stream); // wait for points to flush
@@ -341,7 +367,7 @@ mod tests {
 
         // validate that the requests were flushed based on the max_records value, not the
         // max request delay
-        assert_eq!(requests.len(), 25);
+        assert_eq!(requests.len(), 35);
 
         let r = requests
             .iter()
@@ -373,12 +399,59 @@ mod tests {
             panic!("invalid struct points type");
         };
 
-        // collect() overwrites into a single request
+        let PointsType::ArrayPoints(ArrayPoints {
+            array_type: Some(ArrayType::DoubleArrayPoints(dap)),
+        }) = r.get("double_array").unwrap()
+        else {
+            panic!("invalid double array points type");
+        };
+
+        let PointsType::ArrayPoints(ArrayPoints {
+            array_type: Some(ArrayType::StringArrayPoints(sap)),
+        }) = r.get("string_array").unwrap()
+        else {
+            panic!("invalid string array points type");
+        };
+
+        // collect() overwrites into a single request per channel
         assert_eq!(dp.points.len(), 1000);
         assert_eq!(sp.points.len(), 1000);
         assert_eq!(ip.points.len(), 1000);
         assert_eq!(up.points.len(), 1000);
         assert_eq!(stp.points.len(), 1000);
+        assert_eq!(dap.points.len(), 1000);
+        assert_eq!(sap.points.len(), 1000);
+    }
+
+    #[test_log::test]
+    #[should_panic(expected = "mismatched types")]
+    fn test_mismatched_array_types_panics() {
+        // Protects the exhaustive match in SeriesBufferGuard::extend from being
+        // silently simplified to a catch-all: pushing a DoubleArray and then a
+        // StringArray to the same channel must panic at buffer merge time.
+        //
+        // ManuallyDrop skips NominalDatasetStream::drop during unwind — the panic
+        // leaves unflushed_points non-zero, which would cause drop to spin forever.
+        let (_test_consumer, stream) = create_test_stream();
+        let stream = std::mem::ManuallyDrop::new(stream);
+        let cd = ChannelDescriptor::new("mixed_array");
+
+        let ts = UNIX_EPOCH.elapsed().unwrap().into_timestamp();
+
+        stream.enqueue(
+            &cd,
+            vec![DoubleArrayPoint {
+                timestamp: Some(ts),
+                value: vec![1.0, 2.0],
+            }],
+        );
+        stream.enqueue(
+            &cd,
+            vec![StringArrayPoint {
+                timestamp: Some(ts),
+                value: vec!["a".into()],
+            }],
+        );
     }
 
     #[test_log::test]
@@ -440,11 +513,15 @@ mod tests {
         let cd3 = ChannelDescriptor::new("int");
         let cd4 = ChannelDescriptor::new("uint64");
         let cd5 = ChannelDescriptor::new("struct");
+        let cd6 = ChannelDescriptor::new("double_array");
+        let cd7 = ChannelDescriptor::new("string_array");
         let mut double_writer = stream.double_writer(cd1);
         let mut string_writer = stream.string_writer(cd2);
         let mut integer_writer = stream.integer_writer(cd3);
         let mut uint64_writer = stream.uint64_writer(cd4);
         let mut struct_writer = stream.struct_writer(cd5);
+        let mut double_array_writer = stream.double_array_writer(cd6);
+        let mut string_array_writer = stream.string_array_writer(cd7);
 
         for i in 0..5000 {
             let start_time = UNIX_EPOCH.elapsed().unwrap();
@@ -453,7 +530,9 @@ mod tests {
             string_writer.push(start_time, format!("{}", value));
             integer_writer.push(start_time, value);
             uint64_writer.push(start_time, value as u64);
-            struct_writer.push(start_time, format!("{}", value));
+            struct_writer.push(start_time, format!("{{\"v\":{}}}", value));
+            double_array_writer.push(start_time, vec![value as f64, (value + 1) as f64]);
+            string_array_writer.push(start_time, vec![format!("{}", value)]);
         }
 
         drop(double_writer);
@@ -461,11 +540,13 @@ mod tests {
         drop(integer_writer);
         drop(uint64_writer);
         drop(struct_writer);
+        drop(double_array_writer);
+        drop(string_array_writer);
         drop(stream);
 
         let requests = test_consumer.requests.lock().unwrap();
 
-        assert_eq!(requests.len(), 25);
+        assert_eq!(requests.len(), 35);
 
         let r = requests
             .iter()
@@ -498,11 +579,27 @@ mod tests {
             panic!("invalid struct points type");
         };
 
-        // collect() overwrites into a single request
+        let PointsType::ArrayPoints(ArrayPoints {
+            array_type: Some(ArrayType::DoubleArrayPoints(dap)),
+        }) = r.get("double_array").unwrap()
+        else {
+            panic!("invalid double array points type");
+        };
+
+        let PointsType::ArrayPoints(ArrayPoints {
+            array_type: Some(ArrayType::StringArrayPoints(sap)),
+        }) = r.get("string_array").unwrap()
+        else {
+            panic!("invalid string array points type");
+        };
+
+        // collect() overwrites into a single request per channel
         assert_eq!(dp.points.len(), 1000);
         assert_eq!(sp.points.len(), 1000);
         assert_eq!(ip.points.len(), 1000);
         assert_eq!(up.points.len(), 1000);
         assert_eq!(stp.points.len(), 1000);
+        assert_eq!(dap.points.len(), 1000);
+        assert_eq!(sap.points.len(), 1000);
     }
 }

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -17,10 +17,12 @@ use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
 use nominal_api::tonic::io::nominal::scout::api::proto::points::PointsType;
 use nominal_api::tonic::io::nominal::scout::api::proto::ArrayPoints;
 use nominal_api::tonic::io::nominal::scout::api::proto::Channel;
+use nominal_api::tonic::io::nominal::scout::api::proto::DoubleArrayPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::Points;
 use nominal_api::tonic::io::nominal::scout::api::proto::Series;
+use nominal_api::tonic::io::nominal::scout::api::proto::StringArrayPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::StructPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::Uint64Point;
@@ -357,6 +359,25 @@ impl NominalDatasetStream {
             writer: NominalChannelWriter::new(self, channel_descriptor),
         }
     }
+
+    pub fn double_array_writer(
+        &self,
+        channel_descriptor: ChannelDescriptor,
+    ) -> NominalDoubleArrayWriter<'_> {
+        NominalDoubleArrayWriter {
+            writer: NominalChannelWriter::new(self, channel_descriptor),
+        }
+    }
+
+    pub fn string_array_writer(
+        &self,
+        channel_descriptor: ChannelDescriptor,
+    ) -> NominalStringArrayWriter<'_> {
+        NominalStringArrayWriter {
+            writer: NominalChannelWriter::new(self, channel_descriptor),
+        }
+    }
+
     pub fn enqueue(&self, channel_descriptor: &ChannelDescriptor, new_points: impl IntoPoints) {
         let new_points = new_points.into_points();
         let new_count = points_len(&new_points);
@@ -523,6 +544,36 @@ impl NominalStructWriter<'_> {
         self.writer.push_point(StructPoint {
             timestamp: Some(timestamp.into_timestamp()),
             json_string: value.into(),
+        });
+    }
+}
+
+pub struct NominalDoubleArrayWriter<'ds> {
+    writer: NominalChannelWriter<'ds, DoubleArrayPoint>,
+}
+
+impl NominalDoubleArrayWriter<'_> {
+    pub fn push(&mut self, timestamp: impl IntoTimestamp, value: Vec<f64>) {
+        self.writer.push_point(DoubleArrayPoint {
+            timestamp: Some(timestamp.into_timestamp()),
+            value,
+        });
+    }
+}
+
+pub struct NominalStringArrayWriter<'ds> {
+    writer: NominalChannelWriter<'ds, StringArrayPoint>,
+}
+
+impl NominalStringArrayWriter<'_> {
+    pub fn push(
+        &mut self,
+        timestamp: impl IntoTimestamp,
+        value: impl IntoIterator<Item = impl Into<String>>,
+    ) {
+        self.writer.push_point(StringArrayPoint {
+            timestamp: Some(timestamp.into_timestamp()),
+            value: value.into_iter().map(Into::into).collect(),
         });
     }
 }

--- a/nominal-streaming/src/types.rs
+++ b/nominal-streaming/src/types.rs
@@ -4,11 +4,17 @@ use std::time::Duration;
 use conjure_object::BearerToken;
 use nominal_api::objects::api::rids::WorkspaceRid;
 use nominal_api::tonic::google::protobuf::Timestamp;
+use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
 use nominal_api::tonic::io::nominal::scout::api::proto::points::PointsType;
+use nominal_api::tonic::io::nominal::scout::api::proto::ArrayPoints;
+use nominal_api::tonic::io::nominal::scout::api::proto::DoubleArrayPoint;
+use nominal_api::tonic::io::nominal::scout::api::proto::DoubleArrayPoints;
 use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::DoublePoints;
 use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::IntegerPoints;
+use nominal_api::tonic::io::nominal::scout::api::proto::StringArrayPoint;
+use nominal_api::tonic::io::nominal::scout::api::proto::StringArrayPoints;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoint;
 use nominal_api::tonic::io::nominal::scout::api::proto::StringPoints;
 use nominal_api::tonic::io::nominal::scout::api::proto::StructPoint;
@@ -104,6 +110,26 @@ impl IntoPoints for Vec<Uint64Point> {
     }
 }
 
+impl IntoPoints for Vec<DoubleArrayPoint> {
+    fn into_points(self) -> PointsType {
+        PointsType::ArrayPoints(ArrayPoints {
+            array_type: Some(ArrayType::DoubleArrayPoints(DoubleArrayPoints {
+                points: self,
+            })),
+        })
+    }
+}
+
+impl IntoPoints for Vec<StringArrayPoint> {
+    fn into_points(self) -> PointsType {
+        PointsType::ArrayPoints(ArrayPoints {
+            array_type: Some(ArrayType::StringArrayPoints(StringArrayPoints {
+                points: self,
+            })),
+        })
+    }
+}
+
 pub trait IntoTimestamp {
     fn into_timestamp(self) -> Timestamp;
 }
@@ -132,5 +158,46 @@ impl IntoTimestamp for i64 {
             seconds: (self / NANOS_PER_SECOND),
             nanos: (self % NANOS_PER_SECOND) as i32,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nominal_api::tonic::io::nominal::scout::api::proto::array_points::ArrayType;
+    use nominal_api::tonic::io::nominal::scout::api::proto::DoubleArrayPoint;
+    use nominal_api::tonic::io::nominal::scout::api::proto::StringArrayPoint;
+
+    use super::*;
+
+    #[test]
+    fn vec_double_array_point_converts_to_points_type() {
+        let points = vec![DoubleArrayPoint {
+            timestamp: None,
+            value: vec![1.0, 2.0, 3.0],
+        }];
+        let PointsType::ArrayPoints(arr) = points.into_points() else {
+            panic!("expected ArrayPoints");
+        };
+        let Some(ArrayType::DoubleArrayPoints(dp)) = arr.array_type else {
+            panic!("expected DoubleArrayPoints");
+        };
+        assert_eq!(dp.points.len(), 1);
+        assert_eq!(dp.points[0].value, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn vec_string_array_point_converts_to_points_type() {
+        let points = vec![StringArrayPoint {
+            timestamp: None,
+            value: vec!["a".into(), "b".into()],
+        }];
+        let PointsType::ArrayPoints(arr) = points.into_points() else {
+            panic!("expected ArrayPoints");
+        };
+        let Some(ArrayType::StringArrayPoints(sp)) = arr.array_type else {
+            panic!("expected StringArrayPoints");
+        };
+        assert_eq!(sp.points.len(), 1);
+        assert_eq!(sp.points[0].value, vec!["a", "b"]);
     }
 }

--- a/py-nominal-streaming/examples/test_struct_array.py
+++ b/py-nominal-streaming/examples/test_struct_array.py
@@ -1,0 +1,63 @@
+"""Smoke test for struct and array series enqueues against a live dataset.
+
+Run: `uv run python py-nominal-streaming/examples/test_struct_array.py`
+Requires: NominalClient profile "staging" with a valid token.
+"""
+
+import logging
+import time
+
+from nominal.core import NominalClient
+from nominal_streaming import NominalDatasetStream, PyNominalStreamOpts
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    client = NominalClient.from_profile("staging")
+    dataset = client.create_dataset("py-nominal-streaming struct+array smoke")
+
+    auth_header = client._clients.auth_header.split()[-1]
+    base_api_url = client._clients.authentication._uri
+
+    stream = (
+        NominalDatasetStream(
+            auth_header=auth_header,
+            opts=PyNominalStreamOpts(base_api_url=base_api_url),
+        )
+        .enable_logging("info")
+        .with_core_consumer(dataset.rid)
+    )
+    logger.info("Streaming to dataset %s", dataset.nominal_url)
+
+    now_ns = int(time.time() * 1e9)
+    with stream:
+        # struct channel
+        for i in range(100):
+            stream.enqueue_struct(
+                "struct_ch",
+                now_ns + i * 1_000_000,
+                {"i": i, "label": f"row-{i}", "nested": {"ok": True}},
+            )
+        # float array channel
+        for i in range(100):
+            stream.enqueue_float_array(
+                "float_array_ch",
+                now_ns + i * 1_000_000,
+                [float(i), float(i) + 0.5, float(i) + 1.0],
+            )
+        # string array channel
+        for i in range(100):
+            stream.enqueue_string_array(
+                "string_array_ch",
+                now_ns + i * 1_000_000,
+                [f"a{i}", f"b{i}"],
+            )
+
+    logger.info("Done; dataset %s", dataset.nominal_url)
+    dataset.archive()
+
+
+if __name__ == "__main__":
+    main()

--- a/py-nominal-streaming/python/nominal_streaming/_nominal_streaming.pyi
+++ b/py-nominal-streaming/python/nominal_streaming/_nominal_streaming.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pathlib
 from types import TracebackType
-from typing import Sequence, Type
+from typing import Any, Mapping, Sequence, Type
 
 from typing_extensions import Self
 
@@ -371,6 +371,70 @@ class PyNominalDatasetStream:
         Raises:
             RuntimeError: If the stream is not open or has been cancelled.
             TypeError: If any value is not an `int`, `float`, or `str`.
+        """
+
+    def enqueue_struct(
+        self,
+        channel_name: str,
+        timestamp: int,
+        value: Mapping[str, Any],
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """Enqueue a single struct value.
+
+        The value is JSON-serialized inside Rust using Python's json.dumps
+        (with allow_nan=False). Raises TypeError at enqueue time if the
+        value contains non-JSON-native elements.
+
+        Args:
+            channel_name: Channel name to stream to
+            timestamp: Integral nanoseconds since unix epoch.
+            value: Struct value, must be JSON-encodable.
+            tags: Optional tags to attach to the data.
+
+        Raises:
+            RuntimeError: If the stream is not open or has been cancelled.
+            TypeError: If `value` contains a non-JSON-native element.
+        """
+
+    def enqueue_float_array(
+        self,
+        channel_name: str,
+        timestamp: int,
+        value: Sequence[float],
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """Enqueue a single array-of-doubles value.
+
+        Args:
+            channel_name: Channel name to stream to
+            timestamp: Integral nanoseconds since unix epoch.
+            value: Sequence of doubles forming the array value at this timestamp.
+                Integer elements are coerced to float; pass an explicit float
+                sequence if implicit int-to-float promotion is undesired.
+            tags: Optional tags to attach to the data.
+
+        Raises:
+            RuntimeError: If the stream is not open or has been cancelled.
+        """
+
+    def enqueue_string_array(
+        self,
+        channel_name: str,
+        timestamp: int,
+        value: Sequence[str],
+        tags: dict[str, str] | None = None,
+    ) -> None:
+        """Enqueue a single array-of-strings value.
+
+        Args:
+            channel_name: Channel name to stream to
+            timestamp: Integral nanoseconds since unix epoch.
+            value: Sequence of strings forming the array value at this timestamp.
+            tags: Optional tags to attach to the data.
+
+        Raises:
+            RuntimeError: If the stream is not open or has been cancelled.
         """
 
     def __enter__(self) -> Self: ...

--- a/py-nominal-streaming/python/nominal_streaming/nominal_dataset_stream.py
+++ b/py-nominal-streaming/python/nominal_streaming/nominal_dataset_stream.py
@@ -36,7 +36,7 @@ import pathlib
 import signal
 import threading
 from types import TracebackType
-from typing import Mapping, Sequence, Type
+from typing import Any, Mapping, Sequence, Type
 
 import dateutil
 from typing_extensions import Self
@@ -312,3 +312,76 @@ class NominalDatasetStream:
             tags: Key-value tags associated with the data being uploaded.
         """
         self._impl.enqueue_from_dict(_parse_timestamp(timestamp), {**channel_values}, {**tags} if tags else None)
+
+    def enqueue_struct(
+        self,
+        channel_name: str,
+        timestamp: TimestampLike,
+        value: Mapping[str, Any],
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        """Write a single struct value (JSON-encoded inside Rust) to the stream.
+
+        Args:
+            channel_name: Name of the channel to upload data for.
+            timestamp: Absolute UTC timestamp of the data being uploaded.
+            value: Mapping to serialize as a JSON struct. Nested values must be
+                JSON-native (int, float, str, bool, None, list, dict). Non-native
+                types (datetime, numpy scalars, etc.) must be converted by the caller.
+            tags: Key-value tags associated with the data being uploaded.
+
+        Raises:
+            TypeError: If `value` contains a non-JSON-native element.
+        """
+        self._impl.enqueue_struct(
+            channel_name,
+            _parse_timestamp(timestamp),
+            {**value},
+            {**tags} if tags else None,
+        )
+
+    def enqueue_float_array(
+        self,
+        channel_name: str,
+        timestamp: TimestampLike,
+        value: Sequence[float],
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        """Write a single array-of-doubles value to the stream.
+
+        Args:
+            channel_name: Name of the channel to upload data for.
+            timestamp: Absolute UTC timestamp of the data being uploaded.
+            value: Sequence of doubles forming the array value at this timestamp.
+                Integer elements are coerced to float; pass an explicit float
+                sequence if implicit int-to-float promotion is undesired.
+            tags: Key-value tags associated with the data being uploaded.
+        """
+        self._impl.enqueue_float_array(
+            channel_name,
+            _parse_timestamp(timestamp),
+            list(value),
+            {**tags} if tags else None,
+        )
+
+    def enqueue_string_array(
+        self,
+        channel_name: str,
+        timestamp: TimestampLike,
+        value: Sequence[str],
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        """Write a single array-of-strings value to the stream.
+
+        Args:
+            channel_name: Name of the channel to upload data for.
+            timestamp: Absolute UTC timestamp of the data being uploaded.
+            value: Sequence of strings forming the array value at this timestamp.
+            tags: Key-value tags associated with the data being uploaded.
+        """
+        self._impl.enqueue_string_array(
+            channel_name,
+            _parse_timestamp(timestamp),
+            list(value),
+            {**tags} if tags else None,
+        )

--- a/py-nominal-streaming/src/nominal_dataset_stream.rs
+++ b/py-nominal-streaming/src/nominal_dataset_stream.rs
@@ -11,6 +11,7 @@ use ::nominal_streaming::prelude::*;
 use nominal_streaming::prelude::BearerToken;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
 use pyo3::types::PyDict;
 use tracing::info;
 use tracing::warn;
@@ -23,6 +24,15 @@ use crate::nominal_stream_opts::PyNominalStreamOpts;
 use crate::point::*;
 use crate::runtime::spawn_runtime_worker;
 use crate::runtime::StreamRuntime;
+
+static JSON_DUMPS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
+fn json_dumps<'py>(py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    let cached = JSON_DUMPS.get_or_try_init(py, || -> PyResult<Py<PyAny>> {
+        Ok(py.import("json")?.getattr("dumps")?.unbind())
+    })?;
+    Ok(cached.bind(py).clone())
+}
 
 fn extract_single_enqueue_item(
     channel_descriptor: ChannelDescriptor,
@@ -299,6 +309,61 @@ impl PyNominalDatasetStream {
         }
 
         self.send_many(py, items)
+    }
+
+    #[pyo3(
+        signature = (channel_name, timestamp, value, tags=None),
+        text_signature = "(self, channel_name, timestamp, value, tags=None)"
+    )]
+    pub fn enqueue_struct(
+        &self,
+        py: Python<'_>,
+        channel_name: &str,
+        timestamp: u64,
+        value: &Bound<'_, PyAny>,
+        tags: Option<HashMap<String, String>>,
+    ) -> PyResult<()> {
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("allow_nan", false)?;
+        let json_string: String = json_dumps(py)?.call((value,), Some(&kwargs))?.extract()?;
+
+        let ts = parse_timestamp(timestamp);
+        let ch = description_with_tags(channel_name, tags);
+        self.send_one(py, single_struct(ch, ts, json_string))
+    }
+
+    #[pyo3(
+        signature = (channel_name, timestamp, value, tags=None),
+        text_signature = "(self, channel_name, timestamp, value, tags=None)"
+    )]
+    pub fn enqueue_float_array(
+        &self,
+        py: Python<'_>,
+        channel_name: &str,
+        timestamp: u64,
+        value: Vec<f64>,
+        tags: Option<HashMap<String, String>>,
+    ) -> PyResult<()> {
+        let ts = parse_timestamp(timestamp);
+        let ch = description_with_tags(channel_name, tags);
+        self.send_one(py, single_double_array(ch, ts, value))
+    }
+
+    #[pyo3(
+        signature = (channel_name, timestamp, value, tags=None),
+        text_signature = "(self, channel_name, timestamp, value, tags=None)"
+    )]
+    pub fn enqueue_string_array(
+        &self,
+        py: Python<'_>,
+        channel_name: &str,
+        timestamp: u64,
+        value: Vec<String>,
+        tags: Option<HashMap<String, String>>,
+    ) -> PyResult<()> {
+        let ts = parse_timestamp(timestamp);
+        let ch = description_with_tags(channel_name, tags);
+        self.send_one(py, single_string_array(ch, ts, value))
     }
 
     fn __enter__<'py>(mut slf: PyRefMut<'py, Self>) -> PyResult<PyRefMut<'py, Self>> {

--- a/py-nominal-streaming/src/point.rs
+++ b/py-nominal-streaming/src/point.rs
@@ -44,6 +44,18 @@ pub enum EnqueueItem {
         ch: ChannelDescriptor,
         points: Vec<StringPoint>,
     },
+    Structs {
+        ch: ChannelDescriptor,
+        points: Vec<StructPoint>,
+    },
+    DoubleArrays {
+        ch: ChannelDescriptor,
+        points: Vec<DoubleArrayPoint>,
+    },
+    StringArrays {
+        ch: ChannelDescriptor,
+        points: Vec<StringArrayPoint>,
+    },
 }
 
 /// Ensure the given lists of timestamps and values have the same length
@@ -118,6 +130,39 @@ pub fn single_string(ch: ChannelDescriptor, ts: Timestamp, v: String) -> Enqueue
         points: vec![StringPoint {
             timestamp: Some(ts),
             value: v,
+        }],
+    }
+}
+pub fn single_struct(ch: ChannelDescriptor, ts: Timestamp, json_string: String) -> EnqueueItem {
+    EnqueueItem::Structs {
+        ch,
+        points: vec![StructPoint {
+            timestamp: Some(ts),
+            json_string,
+        }],
+    }
+}
+
+pub fn single_double_array(ch: ChannelDescriptor, ts: Timestamp, value: Vec<f64>) -> EnqueueItem {
+    EnqueueItem::DoubleArrays {
+        ch,
+        points: vec![DoubleArrayPoint {
+            timestamp: Some(ts),
+            value,
+        }],
+    }
+}
+
+pub fn single_string_array(
+    ch: ChannelDescriptor,
+    ts: Timestamp,
+    value: Vec<String>,
+) -> EnqueueItem {
+    EnqueueItem::StringArrays {
+        ch,
+        points: vec![StringArrayPoint {
+            timestamp: Some(ts),
+            value,
         }],
     }
 }

--- a/py-nominal-streaming/src/runtime.rs
+++ b/py-nominal-streaming/src/runtime.rs
@@ -99,9 +99,12 @@ pub fn spawn_runtime_worker(
                     },
                     maybe_item = ingest_rx.recv() => {
                         match maybe_item {
-                            Some(EnqueueItem::Doubles { ch, points }) => { stream.enqueue(&ch, points); }
-                            Some(EnqueueItem::Ints    { ch, points }) => { stream.enqueue(&ch, points); }
-                            Some(EnqueueItem::Strings { ch, points }) => { stream.enqueue(&ch, points); }
+                            Some(EnqueueItem::Doubles      { ch, points }) => { stream.enqueue(&ch, points); }
+                            Some(EnqueueItem::Ints         { ch, points }) => { stream.enqueue(&ch, points); }
+                            Some(EnqueueItem::Strings      { ch, points }) => { stream.enqueue(&ch, points); }
+                            Some(EnqueueItem::Structs      { ch, points }) => { stream.enqueue(&ch, points); }
+                            Some(EnqueueItem::DoubleArrays { ch, points }) => { stream.enqueue(&ch, points); }
+                            Some(EnqueueItem::StringArrays { ch, points }) => { stream.enqueue(&ch, points); }
                             None => {
                                 info!("Empty enqueue item received! Stopping runtime...");
                                 break;


### PR DESCRIPTION
* Adds in support for struct and array series when streaming from python
* Adds in convenience helpers to the rust codebase for enqueueing arrays and structs
* Adds in tests for newly added functionality.