### PR TITLE
feat: allow file-only NominalDatasetStream without API credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Python: `auth_header` and `opts` arguments to `NominalDatasetStream(...)` are now optional, allowing file-only streams to be configured via `to_file(...)` without supplying Nominal API credentials.
+
 ## [0.8.2](https://github.com/nominal-io/nominal-streaming/compare/v0.8.1...v0.8.2) - 2026-04-22
 
 ### Added

--- a/py-nominal-streaming/examples/test_file_only.py
+++ b/py-nominal-streaming/examples/test_file_only.py
@@ -1,0 +1,35 @@
+"""Stream points to a local avro file without configuring a Nominal API consumer.
+
+Run: `uv run python py-nominal-streaming/examples/test_file_only.py`
+
+No Nominal credentials are required: the stream is configured with `to_file(...)`
+only, so no `auth_header` or `dataset_rid` is provided.
+"""
+
+import logging
+import pathlib
+import tempfile
+import time
+
+from nominal_streaming import NominalDatasetStream
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out_path = pathlib.Path(tmp) / "out.avro"
+        stream = NominalDatasetStream().enable_logging("info").to_file(out_path)
+
+        now_ns = int(time.time() * 1e9)
+        with stream:
+            for i in range(1000):
+                stream.enqueue("file_only_channel", now_ns + i * 1_000_000, float(i))
+
+        logger.info("Wrote %d bytes to %s", out_path.stat().st_size, out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/py-nominal-streaming/python/nominal_streaming/nominal_dataset_stream.py
+++ b/py-nominal-streaming/python/nominal_streaming/nominal_dataset_stream.py
@@ -26,6 +26,10 @@ with (
     stream.enqueue_batch("chanB", [0, 1_000_000_000], [5, 6], tags={"phase": "prod"})
     stream.enqueue_from_dict(0, {"chanC": "ok", "chanD": 7}, tags={"who": "tester"})
 
+# To stream to a local file only (no Nominal API credentials required):
+with NominalDatasetStream().to_file(pathlib.Path("/tmp/out.avro")) as stream:
+    stream.enqueue("chanA", datetime.now(timezone.utc), 1.23)
+
 """
 
 from __future__ import annotations
@@ -68,12 +72,13 @@ def _parse_timestamp(ts: str | int | datetime.datetime) -> int:
 class NominalDatasetStream:
     """Top-level python wrapper for the Rust streaming client to Nominal."""
 
-    def __init__(self, auth_header: str, opts: PyNominalStreamOpts):
+    def __init__(self, auth_header: str | None = None, opts: PyNominalStreamOpts | None = None):
         """Initializer for dataset stream.
 
         Args:
-            auth_header: API key or access token to the Nominal API
-            opts: Optional options for the underlying stream
+            auth_header: API key or access token to the Nominal API. May be omitted when only writing
+                to a local file via `to_file(...)`; required when calling `with_core_consumer(...)`.
+            opts: Optional options for the underlying stream. If omitted, sensible defaults are used.
         """
         self._auth_header = auth_header
         self._opts = opts
@@ -136,6 +141,10 @@ class NominalDatasetStream:
 
         Args:
             dataset_rid: RID of the Dataset in Nominal to stream to
+
+        Raises:
+            RuntimeError: If no `auth_header` was provided to the constructor and the
+                `NOMINAL_TOKEN` environment variable is not set.
         """
         self._impl = self._impl.with_core_consumer(dataset_rid, self._auth_header)
         return self


### PR DESCRIPTION
## Summary

- Make `auth_header` and `opts` optional on `NominalDatasetStream(...)` so callers using only `to_file(...)` no longer need to supply a Nominal API token or dataset rid.
- The Rust side already supports a file-only target (validation passes if `to_file(...)` is set), but the Python wrapper required `auth_header` at construction time. This relaxes that requirement without changing behavior for callers that go through `with_core_consumer(...)`: the underlying Rust binding still falls back to the `NOMINAL_TOKEN` environment variable and raises a clear `RuntimeError` if neither is set.
- Adds `py-nominal-streaming/examples/test_file_only.py` demonstrating the file-only flow and updates the docstring example.

## Test plan

- [x] `just python::check` passes (ruff format/check + mypy)
- [x] `cargo cleanup` is clean
- [x] `uv run python py-nominal-streaming/examples/test_file_only.py` writes a non-empty avro file with no token configured
- [x] `NominalDatasetStream().with_core_consumer(...)` (no token, no env var) raises `RuntimeError: NOMINAL_TOKEN not set and no token provided`