### PR TITLE
feat: log per-batch upload progress at INFO

### DIFF
--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -962,7 +962,7 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
                 match consumer.consume(&request) {
                     Ok(_) => {
                         let time = req_start.elapsed().as_millis();
-                        debug!("request of {} points sent in {} ms", point_count, time);
+                        info!("request of {} points sent in {} ms", point_count, time);
                         total_request_time += time as u64;
                     }
                     Err(e) => {


### PR DESCRIPTION
## Summary
Promotes the `request of N points sent in M ms` log line in `request_dispatcher` from DEBUG to INFO. This is the per-flush upload progress signal (fires once per HTTP batch), so customers get visible upload progress by default without needing `RUST_LOG=...=debug`.

## Test plan
- [x] `cargo check` clean, no new warnings