### PR TITLE
fix: bounded retry-with-backoff in request_dispatcher + bumped streaming timeouts

### DIFF
--- a/nominal-streaming/src/client.rs
+++ b/nominal-streaming/src/client.rs
@@ -112,6 +112,10 @@ pub static PRODUCTION_CLIENTS: LazyLock<NominalApiClients> =
     LazyLock::new(|| NominalApiClients::from_uri(PRODUCTION_API_URL));
 
 pub fn async_conjure_streaming_client(uri: Url) -> Result<Client, Error> {
+    // Hermeus 2026-05: bumped from 1s/2s/2s -> 5s/15s/15s. The customer's
+    // flight-test network has latency spikes that exhausted the prior tight
+    // timeouts, which then cascaded into batch loss because the dispatcher
+    // does not retry on consumer error.
     Client::builder()
         .service("core-streaming-rs")
         .user_agent(UserAgent::new(Agent::new(
@@ -119,11 +123,11 @@ pub fn async_conjure_streaming_client(uri: Url) -> Result<Client, Error> {
             env!("CARGO_PKG_VERSION"),
         )))
         .uri(uri)
-        .connect_timeout(std::time::Duration::from_secs(1))
-        .read_timeout(std::time::Duration::from_secs(2))
-        .write_timeout(std::time::Duration::from_secs(2))
-        .backoff_slot_size(std::time::Duration::from_millis(10))
-        .max_num_retries(2)
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .read_timeout(std::time::Duration::from_secs(15))
+        .write_timeout(std::time::Duration::from_secs(15))
+        .backoff_slot_size(std::time::Duration::from_millis(50))
+        .max_num_retries(3)
         // enables retries for POST endpoints like the streaming ingest one
         .idempotency(Idempotency::Always)
         .build()

--- a/nominal-streaming/src/client.rs
+++ b/nominal-streaming/src/client.rs
@@ -112,10 +112,6 @@ pub static PRODUCTION_CLIENTS: LazyLock<NominalApiClients> =
     LazyLock::new(|| NominalApiClients::from_uri(PRODUCTION_API_URL));
 
 pub fn async_conjure_streaming_client(uri: Url) -> Result<Client, Error> {
-    // Hermeus 2026-05: bumped from 1s/2s/2s -> 5s/15s/15s. The customer's
-    // flight-test network has latency spikes that exhausted the prior tight
-    // timeouts, which then cascaded into batch loss because the dispatcher
-    // does not retry on consumer error.
     Client::builder()
         .service("core-streaming-rs")
         .user_agent(UserAgent::new(Agent::new(

--- a/nominal-streaming/src/consumer.rs
+++ b/nominal-streaming/src/consumer.rs
@@ -45,6 +45,27 @@ pub enum ConsumerError {
 
 pub type ConsumerResult<T> = Result<T, ConsumerError>;
 
+impl ConsumerError {
+    /// Returns true for errors that cannot succeed on retry (auth, malformed
+    /// request, payload too large, etc.) so the dispatcher can drop the
+    /// batch immediately instead of burning the full retry budget.
+    pub fn is_terminal(&self) -> bool {
+        match self {
+            ConsumerError::MissingTokenError => true,
+            ConsumerError::RequestError(msg) => {
+                let m = msg.as_str();
+                m.contains("400 Bad Request")
+                    || m.contains("401 Unauthorized")
+                    || m.contains("403 Forbidden")
+                    || m.contains("404 Not Found")
+                    || m.contains("413 Payload Too Large")
+                    || m.contains("422 Unprocessable Entity")
+            }
+            _ => false,
+        }
+    }
+}
+
 pub trait WriteRequestConsumer: Send + Sync + Debug {
     fn consume(&self, request: &WriteRequestNominal) -> ConsumerResult<()>;
 }

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -1032,8 +1032,10 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
                                 }
                                 break false;
                             }
-                            let backoff_ms = (DISPATCH_INITIAL_BACKOFF_MS << (attempt - 1).min(20))
-                                .min(DISPATCH_MAX_BACKOFF_MS);
+                            let backoff_scale = (f64::from(attempt) + 1.0).log2();
+                            let backoff_ms = ((DISPATCH_INITIAL_BACKOFF_MS as f64) * backoff_scale)
+                                .min(DISPATCH_MAX_BACKOFF_MS as f64)
+                                as u64;
                             info!(
                                 "dispatcher consume attempt {} failed ({} points), \
                                  retrying in {} ms: {}",

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -1065,8 +1065,17 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
 
                 if unflushed_points.load(Ordering::Acquire) == 0 && !running.load(Ordering::Acquire)
                 {
-                    info!("all points flushed, closing dispatcher thread");
-                    // notify the processor thread that all points have been flushed
+                    let points_lost_at_shutdown = dispatch_metrics
+                        .points_dropped_after_retries
+                        .load(Ordering::Relaxed);
+                    if points_lost_at_shutdown > 0 {
+                        info!(
+                            points_lost_at_shutdown,
+                            "dispatcher closing with points lost to retry exhaustion"
+                        );
+                    } else {
+                        info!("all points flushed, closing dispatcher thread");
+                    }
                     drop(request_rx);
                     break;
                 }

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -975,11 +975,8 @@ impl Drop for NominalDatasetStream {
     }
 }
 
-/// Bounded retry loop around `consumer.consume(...)`. Without this the
-/// dispatcher dropped any batch on the first consumer error, costing all
-/// channels carried in that batch. Backoff is exponential and capped, so a
-/// long server outage still progresses (data lost only after the full
-/// retry budget is exhausted) instead of stalling the dispatcher forever.
+/// Without bounded retries here the dispatcher loses an entire batch
+/// (all channels carried in it) on the first transient consumer error.
 pub const DISPATCH_MAX_ATTEMPTS: u32 = 6;
 pub const DISPATCH_INITIAL_BACKOFF_MS: u64 = 250;
 pub const DISPATCH_MAX_BACKOFF_MS: u64 = 5_000;
@@ -1022,18 +1019,15 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
                             break true;
                         }
                         Err(e) => {
-                            // MissingTokenError is a user error, not transient -- do not retry.
-                            let is_terminal_auth =
+                            let is_terminal_user_error =
                                 matches!(e, crate::consumer::ConsumerError::MissingTokenError);
                             let msg = format!("{e:?}");
                             last_err = Some(msg.clone());
-                            if is_terminal_auth || attempt >= DISPATCH_MAX_ATTEMPTS {
+                            if is_terminal_user_error || attempt >= DISPATCH_MAX_ATTEMPTS {
                                 break false;
                             }
                             let backoff_ms = (DISPATCH_INITIAL_BACKOFF_MS << (attempt - 1).min(20))
                                 .min(DISPATCH_MAX_BACKOFF_MS);
-                            // info-level so retries are visible in production logs but
-                            // do not flood at error level on every blip.
                             info!(
                                 "dispatcher consume attempt {} failed ({} points), \
                                  retrying in {} ms: {}",

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -1019,11 +1019,17 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
                             break true;
                         }
                         Err(e) => {
-                            let is_terminal_user_error =
-                                matches!(e, crate::consumer::ConsumerError::MissingTokenError);
+                            let is_terminal_user_error = e.is_terminal();
                             let msg = format!("{e:?}");
                             last_err = Some(msg.clone());
                             if is_terminal_user_error || attempt >= DISPATCH_MAX_ATTEMPTS {
+                                if is_terminal_user_error {
+                                    error!(
+                                        attempt,
+                                        point_count,
+                                        "dispatcher: terminal consume error, not retrying: {msg}"
+                                    );
+                                }
                                 break false;
                             }
                             let backoff_ms = (DISPATCH_INITIAL_BACKOFF_MS << (attempt - 1).min(20))

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -47,6 +47,25 @@ use crate::types::ChannelDescriptor;
 use crate::types::IntoPoints;
 use crate::types::IntoTimestamp;
 
+/// Observability counters for the request-dispatcher retry loop.
+///
+/// Exposed via [`NominalDatasetStream::dispatch_metrics`] so callers can poll
+/// these atomics and emit periodic summary logs. All counters are monotonic
+/// for the lifetime of the stream.
+#[derive(Debug, Default)]
+pub struct DispatchMetrics {
+    /// Requests that ultimately succeeded (possibly after retries).
+    pub requests_sent: AtomicU64,
+    /// Requests that needed at least one retry to succeed.
+    pub requests_recovered_via_retry: AtomicU64,
+    /// Total retry attempts across all requests (sum of attempts - 1 per request).
+    pub retry_attempts: AtomicU64,
+    /// Requests that were dropped because all retries failed.
+    pub requests_dropped_after_retries: AtomicU64,
+    /// Total points dropped in those failed requests.
+    pub points_dropped_after_retries: AtomicU64,
+}
+
 #[derive(Debug, Clone)]
 pub struct NominalStreamOpts {
     pub max_points_per_record: usize,
@@ -254,6 +273,7 @@ pub struct NominalDatasetStream {
     secondary_buffer: Arc<SeriesBuffer>,
     primary_handle: thread::JoinHandle<()>,
     secondary_handle: thread::JoinHandle<()>,
+    dispatch_metrics: Arc<DispatchMetrics>,
     /// Records the total time spent processing batches on background threads.
     ///
     /// This field is only available when the `instrument` feature is enabled.
@@ -335,6 +355,7 @@ impl NominalDatasetStream {
             .unwrap();
 
         let consumer = Arc::new(consumer);
+        let dispatch_metrics = Arc::new(DispatchMetrics::default());
 
         for i in 0..opts.request_dispatcher_tasks {
             thread::Builder::new()
@@ -344,6 +365,7 @@ impl NominalDatasetStream {
                     let unflushed_points = Arc::clone(&unflushed_points);
                     let rx = request_rx.clone();
                     let consumer = consumer.clone();
+                    let dispatch_metrics = Arc::clone(&dispatch_metrics);
                     #[cfg(feature = "instrument")]
                     let disp_ns = Arc::clone(&dispatcher_ns);
                     move || {
@@ -353,6 +375,7 @@ impl NominalDatasetStream {
                             unflushed_points,
                             rx,
                             consumer,
+                            dispatch_metrics,
                             #[cfg(feature = "instrument")]
                             disp_ns,
                         );
@@ -369,11 +392,17 @@ impl NominalDatasetStream {
             secondary_buffer,
             primary_handle,
             secondary_handle,
+            dispatch_metrics,
             #[cfg(feature = "instrument")]
             batch_processor_ns,
             #[cfg(feature = "instrument")]
             dispatcher_ns,
         }
+    }
+
+    /// Snapshot of dispatcher retry/drop counters; never resets.
+    pub fn dispatch_metrics(&self) -> Arc<DispatchMetrics> {
+        Arc::clone(&self.dispatch_metrics)
     }
 
     pub fn double_writer(&self, channel_descriptor: ChannelDescriptor) -> NominalDoubleWriter<'_> {
@@ -946,11 +975,21 @@ impl Drop for NominalDatasetStream {
     }
 }
 
+/// Bounded retry loop around `consumer.consume(...)`. Without this the
+/// dispatcher dropped any batch on the first consumer error, costing all
+/// channels carried in that batch. Backoff is exponential and capped, so a
+/// long server outage still progresses (data lost only after the full
+/// retry budget is exhausted) instead of stalling the dispatcher forever.
+pub const DISPATCH_MAX_ATTEMPTS: u32 = 6;
+pub const DISPATCH_INITIAL_BACKOFF_MS: u64 = 250;
+pub const DISPATCH_MAX_BACKOFF_MS: u64 = 5_000;
+
 fn request_dispatcher<C: WriteRequestConsumer + 'static>(
     running: Arc<AtomicBool>,
     unflushed_points: Arc<AtomicUsize>,
     request_rx: crossbeam_channel::Receiver<(WriteRequestNominal, usize)>,
     consumer: Arc<C>,
+    dispatch_metrics: Arc<DispatchMetrics>,
     #[cfg(feature = "instrument")] disp_ns: Arc<AtomicU64>,
 ) {
     let mut total_request_time = 0;
@@ -959,15 +998,73 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
             Ok((request, point_count)) => {
                 debug!("received writerequest from channel");
                 let req_start = Instant::now();
-                match consumer.consume(&request) {
-                    Ok(_) => {
-                        let time = req_start.elapsed().as_millis();
-                        debug!("request of {} points sent in {} ms", point_count, time);
-                        total_request_time += time as u64;
+
+                let mut last_err: Option<String> = None;
+                let mut attempt: u32 = 0;
+                let succeeded = loop {
+                    attempt += 1;
+                    match consumer.consume(&request) {
+                        Ok(_) => {
+                            let time = req_start.elapsed().as_millis();
+                            debug!(
+                                "request of {} points sent in {} ms on attempt {}",
+                                point_count, time, attempt,
+                            );
+                            total_request_time += time as u64;
+                            dispatch_metrics
+                                .requests_sent
+                                .fetch_add(1, Ordering::Relaxed);
+                            if attempt > 1 {
+                                dispatch_metrics
+                                    .requests_recovered_via_retry
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                            break true;
+                        }
+                        Err(e) => {
+                            // MissingTokenError is a user error, not transient -- do not retry.
+                            let is_terminal_auth =
+                                matches!(e, crate::consumer::ConsumerError::MissingTokenError);
+                            let msg = format!("{e:?}");
+                            last_err = Some(msg.clone());
+                            if is_terminal_auth || attempt >= DISPATCH_MAX_ATTEMPTS {
+                                break false;
+                            }
+                            let backoff_ms = (DISPATCH_INITIAL_BACKOFF_MS
+                                << (attempt - 1).min(20))
+                                .min(DISPATCH_MAX_BACKOFF_MS);
+                            // info-level so retries are visible in production logs but
+                            // do not flood at error level on every blip.
+                            info!(
+                                "dispatcher consume attempt {} failed ({} points), \
+                                 retrying in {} ms: {}",
+                                attempt, point_count, backoff_ms, msg,
+                            );
+                            dispatch_metrics
+                                .retry_attempts
+                                .fetch_add(1, Ordering::Relaxed);
+                            thread::sleep(Duration::from_millis(backoff_ms));
+                        }
                     }
-                    Err(e) => {
-                        error!("Failed to send request: {e:?}");
-                    }
+                };
+                if !succeeded {
+                    let dropped = dispatch_metrics
+                        .requests_dropped_after_retries
+                        .fetch_add(1, Ordering::Relaxed)
+                        + 1;
+                    let points_lost = dispatch_metrics
+                        .points_dropped_after_retries
+                        .fetch_add(point_count as u64, Ordering::Relaxed)
+                        + point_count as u64;
+                    error!(
+                        "Failed to send request after {} attempts; dropping batch of {} points \
+                         (dispatcher cumulative: {} batches / {} points dropped). last_error={}",
+                        attempt,
+                        point_count,
+                        dropped,
+                        points_lost,
+                        last_err.as_deref().unwrap_or("<unknown>"),
+                    );
                 }
                 #[cfg(feature = "instrument")]
                 disp_ns.fetch_add(req_start.elapsed().as_nanos() as u64, Ordering::Relaxed);

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -1030,8 +1030,7 @@ fn request_dispatcher<C: WriteRequestConsumer + 'static>(
                             if is_terminal_auth || attempt >= DISPATCH_MAX_ATTEMPTS {
                                 break false;
                             }
-                            let backoff_ms = (DISPATCH_INITIAL_BACKOFF_MS
-                                << (attempt - 1).min(20))
+                            let backoff_ms = (DISPATCH_INITIAL_BACKOFF_MS << (attempt - 1).min(20))
                                 .min(DISPATCH_MAX_BACKOFF_MS);
                             // info-level so retries are visible in production logs but
                             // do not flood at error level on every blip.


### PR DESCRIPTION
## Summary

Three small changes inside `request_dispatcher` + the streaming client so a transient consumer error no longer silently drops the batch.

1. **Bounded retry-with-backoff** in `request_dispatcher`. `consumer.consume(...)` is now retried up to `DISPATCH_MAX_ATTEMPTS` (6) with logarithmic backoff capped at `DISPATCH_MAX_BACKOFF_MS` (5s). `ConsumerError::is_terminal()` (new helper, covers 4xx/auth) short-circuits the loop.
2. **Bumped streaming-client conjure timeouts.** \`connect_timeout\` 1s → 5s; \`read_timeout\` 2s → 15s; \`write_timeout\` 2s → 15s; \`backoff_slot_size\` 10ms → 50ms; \`max_num_retries\` 2 → 3.
3. **\`DispatchMetrics\`** — atomic counters (\`requests_sent\`, \`requests_recovered_via_retry\`, \`retry_attempts\`, \`requests_dropped_after_retries\`, \`points_dropped_after_retries\`) exposed via \`NominalDatasetStream::dispatch_metrics() -> Arc<DispatchMetrics>\`.

Also: \`unflushed_points\` accounting now distinguishes "all flushed" from "shutdown with points lost" in the dispatcher's exit log line.

## Test plan
- [x] \`cargo +nightly fmt --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --all-features\`