### PR TITLE
chore: stop dependabot proposing prost 0.14+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Every published nominal-api-proto requires prost ^0.13.5 (and tonic ^0.13.1), and we
+      # call encode_to_vec() on its generated types -- so our prost has to resolve to the same
+      # 0.13.x. A second prost in the graph means a second, incompatible `Message` trait, which
+      # fails to compile (see #283). 0.13.x updates are still allowed.
+      # Remove this once nominal-api moves to prost 0.14.
+      - dependency-name: "prost"
+        versions: [">= 0.14"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Wait a week before proposing a newly published version: a freshly released crate can be
+    # malicious or simply unstable, and this repo pulls updates daily.
+    cooldown:
+      default-days: 7
     groups:
       external-deps:
         exclude-patterns: ["nominal-api"]


### PR DESCRIPTION
## Why

Dependabot keeps proposing prost `0.13.5` → `0.14.4` (#283), but that bump cannot compile.

Every published `nominal-api-proto` — up to and including the latest `0.1354.0` — requires prost `^0.13.5`, and `tonic 0.13.1` pins prost 0.13 as well. We call `encode_to_vec()` on `nominal-api-proto`'s generated types (`consumer.rs:24,92`, `simulated_consumer.rs:8`), so our prost has to resolve to the *same* 0.13.x. Bumping ours to 0.14 puts two prosts in the graph, which means two incompatible `prost::Message` traits:

```
error[E0599]: no method named `encode_to_vec` found for reference `&WriteRequestNominal` in the current scope
```

There is no workaround on our side: prost appears in our code only for that one trait import, and neither `nominal-api` nor `nominal-api-proto` re-exports its own prost for us to borrow.

## What

Ignore prost `>= 0.14` only, so 0.13.x patch/minor updates keep flowing normally.

Remove this rule once `nominal-api` moves to prost 0.14.

## Follow-up

#283 should be closed — dependabot normally closes a PR itself once a matching ignore rule lands, but it can be closed by hand if it lingers.