### PR TITLE
perf: enqueue directly into the stream, and share channel tag maps

### DIFF
--- a/nominal-streaming/src/lib.rs
+++ b/nominal-streaming/src/lib.rs
@@ -224,6 +224,7 @@ mod tests {
     use crate::simulated_consumer::SimulatedNetworkConsumer;
     use crate::simulated_consumer::SimulatedNetworkFailure;
     use crate::simulated_consumer::SimulatedRetryPolicy;
+    use crate::types::IntoPoints;
 
     #[derive(Debug)]
     struct TestDatasourceStream {
@@ -378,6 +379,91 @@ mod tests {
         } else {
             panic!("unexpected data type");
         }
+    }
+
+    #[test_log::test]
+    fn enqueue_many_writes_every_channel_in_one_batch() {
+        let (test_consumer, stream) = create_test_stream();
+
+        let timestamp = Timestamp {
+            seconds: 1_700_000_000,
+            nanos: 0,
+        };
+
+        // a wide record: many channels sharing one timestamp, written as a single unit
+        let entries: Vec<(ChannelDescriptor, PointsType)> = (0..250)
+            .map(|i| {
+                (
+                    ChannelDescriptor::new(format!("wide_{i}")),
+                    vec![DoublePoint {
+                        timestamp: Some(timestamp),
+                        value: i as f64,
+                    }]
+                    .into_points(),
+                )
+            })
+            .collect();
+
+        stream.enqueue_many(entries);
+
+        drop(stream); // wait for points to flush
+
+        let requests = test_consumer.requests.lock().unwrap();
+        let series: Vec<_> = requests
+            .iter()
+            .flat_map(|request| request.series.iter())
+            .collect();
+
+        assert_eq!(series.len(), 250, "every channel should be represented");
+        for i in 0..250 {
+            assert_eq!(
+                total_double_points(&requests, &format!("wide_{i}")),
+                1,
+                "channel wide_{i} should have exactly one point"
+            );
+        }
+    }
+
+    #[test_log::test]
+    fn enqueue_many_appends_to_channels_already_buffered() {
+        let (test_consumer, stream) = create_test_stream();
+
+        let channel = ChannelDescriptor::with_tags("shared", [("site", "a1")]);
+        let point = |nanos| {
+            vec![DoublePoint {
+                timestamp: Some(Timestamp {
+                    seconds: 1_700_000_000,
+                    nanos,
+                }),
+                value: nanos as f64,
+            }]
+            .into_points()
+        };
+
+        // the same channel, reached once through enqueue and once through enqueue_many, must land
+        // in one series rather than splitting
+        stream.enqueue(&channel, point(1));
+        stream.enqueue_many(vec![(channel.clone(), point(2))]);
+
+        drop(stream); // wait for points to flush
+
+        let requests = test_consumer.requests.lock().unwrap();
+        assert_eq!(total_double_points(&requests, "shared"), 2);
+        let series: Vec<_> = requests
+            .iter()
+            .flat_map(|request| request.series.iter())
+            .filter(|series| {
+                series
+                    .channel
+                    .as_ref()
+                    .is_some_and(|channel| channel.name == "shared")
+            })
+            .collect();
+        assert_eq!(series.len(), 1, "points should share one series");
+        assert_eq!(
+            series[0].tags,
+            HashMap::from([("site".to_string(), "a1".to_string())])
+        );
     }
 
     #[test_log::test]

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -848,8 +848,14 @@ impl SeriesBuffer {
                 };
                 Series {
                     channel: Some(channel),
+                    // the protobuf `Series` owns its tags, so the shared map is copied out here --
+                    // once per channel per flush, rather than once per channel per write
                     tags: tags
-                        .map(|tags| tags.into_iter().collect())
+                        .map(|tags| {
+                            tags.iter()
+                                .map(|(key, value)| (key.clone(), value.clone()))
+                                .collect()
+                        })
                         .unwrap_or_default(),
                     points: Some(points_obj),
                 }

--- a/nominal-streaming/src/stream.rs
+++ b/nominal-streaming/src/stream.rs
@@ -436,6 +436,22 @@ impl NominalDatasetStream {
         });
     }
 
+    /// Enqueues points for many channels as one unit, blocking while both buffers are full.
+    ///
+    /// This reserves capacity and takes the buffer lock once for the whole batch, where the
+    /// equivalent run of [`enqueue`](Self::enqueue) calls would do both once per channel. For a
+    /// wide record -- thousands of channels sharing a timestamp -- that is the difference between
+    /// one buffer insertion and thousands of them.
+    pub fn enqueue_many(&self, entries: Vec<(ChannelDescriptor, PointsType)>) {
+        let new_count = entries.iter().map(|(_, points)| points_len(points)).sum();
+
+        self.when_capacity(new_count, move |mut sb| {
+            for (channel_descriptor, points) in entries {
+                sb.extend(&channel_descriptor, points)
+            }
+        });
+    }
+
     fn when_capacity(&self, new_count: usize, callback: impl FnOnce(SeriesBufferGuard)) {
         self.unflushed_points
             .fetch_add(new_count, Ordering::Release);

--- a/nominal-streaming/src/types.rs
+++ b/nominal-streaming/src/types.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use conjure_object::BearerToken;
@@ -32,7 +33,11 @@ pub struct ChannelDescriptor {
     /// The name of the channel.
     pub name: String,
     /// The tags associated with the channel, if any.
-    pub tags: Option<BTreeMap<String, String>>,
+    ///
+    /// Shared rather than owned: a wide record is thousands of channels written at one timestamp
+    /// all carrying the same tags, so a descriptor per channel would otherwise mean copying the
+    /// same map thousands of times per write.
+    pub tags: Option<Arc<BTreeMap<String, String>>>,
 }
 
 impl ChannelDescriptor {
@@ -53,11 +58,11 @@ impl ChannelDescriptor {
     ) -> Self {
         Self {
             name: name.into(),
-            tags: Some(
+            tags: Some(Arc::new(
                 tags.into_iter()
                     .map(|(key, value)| (key.into(), value.into()))
                     .collect(),
-            ),
+            )),
         }
     }
 }

--- a/py-nominal-streaming/python/nominal_streaming/nominal_dataset_stream.py
+++ b/py-nominal-streaming/python/nominal_streaming/nominal_dataset_stream.py
@@ -277,7 +277,14 @@ class NominalDatasetStream:
             value: Value to write to the specified channel.
             tags: Key-value tags associated with the data being uploaded.
         """
-        self._impl.enqueue(channel_name, _parse_timestamp(timestamp), value, {**tags} if tags else None)
+        # `type(...) is int` inline rather than calling _parse_timestamp: at ~0.1us per enqueue,
+        # the function call itself is a measurable share of the write.
+        self._impl.enqueue(
+            channel_name,
+            timestamp if type(timestamp) is int else _parse_timestamp(timestamp),
+            value,
+            {**tags} if tags else None,
+        )
 
     def enqueue_batch(
         self,
@@ -300,9 +307,18 @@ class NominalDatasetStream:
             values: Values to write to the specified channel.
             tags: Key-value tags associated with the data being uploaded.
         """
-        self._impl.enqueue_batch(
-            channel_name, [_parse_timestamp(ts) for ts in timestamps], values, {**tags} if tags else None
-        )
+        normalized_tags = {**tags} if tags else None
+        try:
+            # Fast path: a sequence of integral nanoseconds needs no work here, and Rust already
+            # validates every element while extracting it. Rebuilding the sequence in Python costs
+            # more than the rest of the call at any real batch size.
+            # The ignore is the point of the fast path: we hand Rust the caller's sequence and use
+            # its type check as ours, rather than paying for a second one in Python.
+            self._impl.enqueue_batch(channel_name, timestamps, values, normalized_tags)  # type: ignore[arg-type]
+        except TypeError:
+            # Some timestamp (or value) was not integral; normalize and let Rust re-check. Nothing
+            # was enqueued by the attempt above -- extraction happens before anything is written.
+            self._impl.enqueue_batch(channel_name, [_parse_timestamp(ts) for ts in timestamps], values, normalized_tags)
 
     def enqueue_from_dict(
         self,
@@ -320,7 +336,13 @@ class NominalDatasetStream:
             channel_values: A dictionary mapping channel names to their respective values.
             tags: Key-value tags associated with the data being uploaded.
         """
-        self._impl.enqueue_from_dict(_parse_timestamp(timestamp), {**channel_values}, {**tags} if tags else None)
+        # A wide record can carry thousands of channels, so copying the mapping would cost more
+        # than the write itself. Plain dicts go straight through; other Mappings still need one.
+        self._impl.enqueue_from_dict(
+            timestamp if type(timestamp) is int else _parse_timestamp(timestamp),
+            channel_values if type(channel_values) is dict else {**channel_values},
+            {**tags} if tags else None,
+        )
 
     def enqueue_struct(
         self,
@@ -344,7 +366,7 @@ class NominalDatasetStream:
         """
         self._impl.enqueue_struct(
             channel_name,
-            _parse_timestamp(timestamp),
+            timestamp if type(timestamp) is int else _parse_timestamp(timestamp),
             value,
             {**tags} if tags else None,
         )
@@ -368,7 +390,7 @@ class NominalDatasetStream:
         """
         self._impl.enqueue_float_array(
             channel_name,
-            _parse_timestamp(timestamp),
+            timestamp if type(timestamp) is int else _parse_timestamp(timestamp),
             value,
             {**tags} if tags else None,
         )
@@ -390,7 +412,7 @@ class NominalDatasetStream:
         """
         self._impl.enqueue_string_array(
             channel_name,
-            _parse_timestamp(timestamp),
+            timestamp if type(timestamp) is int else _parse_timestamp(timestamp),
             value,
             {**tags} if tags else None,
         )

--- a/py-nominal-streaming/src/nominal_dataset_stream.rs
+++ b/py-nominal-streaming/src/nominal_dataset_stream.rs
@@ -34,18 +34,14 @@ fn json_dumps<'py>(py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
     Ok(cached.bind(py).clone())
 }
 
-fn extract_single_enqueue_item(
-    channel_descriptor: ChannelDescriptor,
-    timestamp: Timestamp,
-    value: &Bound<'_, PyAny>,
-) -> Result<EnqueueItem, PyErr> {
+fn extract_single_points(timestamp: Timestamp, value: &Bound<'_, PyAny>) -> PyResult<PointsType> {
     // Try extractions in order: float → int → string
     if let Ok(v) = value.extract::<f64>() {
-        Ok(single_double(channel_descriptor, timestamp, v))
+        Ok(single_double(timestamp, v))
     } else if let Ok(v) = value.extract::<i64>() {
-        Ok(single_int(channel_descriptor, timestamp, v))
+        Ok(single_int(timestamp, v))
     } else if let Ok(v) = value.extract::<String>() {
-        Ok(single_string(channel_descriptor, timestamp, v))
+        Ok(single_string(timestamp, v))
     } else {
         Err(pyo3::exceptions::PyTypeError::new_err(
             "value must be float, int, or str",
@@ -53,25 +49,26 @@ fn extract_single_enqueue_item(
     }
 }
 
-fn extract_series_enqueue_item(
-    channel_descriptor: ChannelDescriptor,
+fn extract_series_points(
     timestamps: Vec<Timestamp>,
     values: &Bound<'_, PyAny>,
-) -> Result<EnqueueItem, PyErr> {
+) -> PyResult<PointsType> {
     match classify_values(values)? {
-        ValueKind::Floats => {
-            series_doubles(channel_descriptor, timestamps, extract_vec_f64(values)?)
-        }
-        ValueKind::Ints => series_ints(channel_descriptor, timestamps, extract_vec_i64(values)?),
-        ValueKind::Strings => {
-            series_strings(channel_descriptor, timestamps, extract_vec_string(values)?)
-        }
+        ValueKind::Floats => series_doubles(timestamps, extract_vec_f64(values)?),
+        ValueKind::Ints => series_ints(timestamps, extract_vec_i64(values)?),
+        ValueKind::Strings => series_strings(timestamps, extract_vec_string(values)?),
     }
 }
 
 /// The PyNominalDatasetStream is a thin layer bound to python that handles two main concerns:
 /// - Configuring and managing a tokio runtime for running streaming code
 /// - Passing data from python, converting it to standard rust types, and pushing into streaming code.
+///
+/// Enqueued points go straight into the underlying stream from the calling python thread.
+/// `NominalDatasetStream::enqueue` is synchronous and `Sync`, so there is nothing to hand off to the
+/// runtime -- it exists only for the uploader. The GIL is released around each call, both so that
+/// other python threads run while the uploader is caught up with and so that several python threads
+/// can enqueue concurrently, contending only on the stream's own buffer lock.
 #[pyclass]
 pub struct PyNominalDatasetStream {
     builder: LazyDatasetStreamBuilder,
@@ -81,12 +78,13 @@ pub struct PyNominalDatasetStream {
 }
 
 impl PyNominalDatasetStream {
-    /// Borrow the active runtime or raise a python error if it hasn't started
+    /// Borrow the underlying stream or raise a python error if it hasn't started
     #[inline]
-    fn runtime(&self) -> PyResult<&StreamRuntime> {
+    fn stream(&self) -> PyResult<&Arc<NominalDatasetStream>> {
         self.runtime
             .as_ref()
-            .ok_or_else(|| PyRuntimeError::new_err("runtime not started"))
+            .map(|rt| &rt.stream)
+            .ok_or_else(|| PyRuntimeError::new_err("stream not open"))
     }
 
     /// Extract nominal api token from env or overridden by argument
@@ -98,33 +96,22 @@ impl PyNominalDatasetStream {
             .ok_or_else(|| PyRuntimeError::new_err("NOMINAL_TOKEN not set and no token provided"))
     }
 
-    fn send_one(&self, py: Python<'_>, item: EnqueueItem) -> PyResult<()> {
-        let runtime = self.runtime()?;
-        py.detach(|| {
-            runtime.runtime_handle.block_on(async move {
-                tokio::select! {
-                    _ = runtime.cancel_token.cancelled() => Err(()),        // cancelled
-                    r = runtime.ingest_tx.send(item) => r.map_err(|_| ()),  // sent or cancelled
-                }
-            })
-        })
-        .map_err(|_| PyRuntimeError::new_err("cancelled or closed"))
+    /// Push one channel's points into the stream, releasing the GIL for the call.
+    fn push_one(&self, py: Python<'_>, ch: ChannelDescriptor, points: PointsType) -> PyResult<()> {
+        let stream = self.stream()?;
+        py.detach(|| stream.enqueue(&ch, points));
+        Ok(())
     }
 
-    fn send_many(&self, py: Python<'_>, items: Vec<EnqueueItem>) -> PyResult<()> {
-        let runtime = self.runtime()?;
-        py.detach(|| {
-            runtime.runtime_handle.block_on(async move {
-                for item in items {
-                    tokio::select! {
-                        _ = runtime.cancel_token.cancelled() => return Err(()), // cancelled
-                        r = runtime.ingest_tx.send(item) => r.map_err(|_| ())?, // sent or cancelled
-                    }
-                }
-                Ok::<(), ()>(())
-            })
-        })
-        .map_err(|_| PyRuntimeError::new_err("cancelled or closed"))
+    /// Push many channels' points into the stream as one unit, releasing the GIL for the call.
+    fn push_many(
+        &self,
+        py: Python<'_>,
+        entries: Vec<(ChannelDescriptor, PointsType)>,
+    ) -> PyResult<()> {
+        let stream = self.stream()?;
+        py.detach(|| stream.enqueue_many(entries));
+        Ok(())
     }
 }
 
@@ -205,35 +192,35 @@ impl PyNominalDatasetStream {
             .validate()
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
-        let (runtime_task, runtime) = spawn_runtime_worker(self.builder.clone())
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let (runtime_task, runtime) = match spawn_runtime_worker(self.builder.clone()) {
+            Ok(parts) => parts,
+            Err(e) => {
+                // leave the stream closed so that a failed open can be retried
+                self.is_open.store(false, Ordering::SeqCst);
+                return Err(PyRuntimeError::new_err(e.to_string()));
+            }
+        };
 
         self.runtime_task = Some(runtime_task);
         self.runtime = Some(runtime);
         Ok(())
     }
 
-    /// Graceful drain and teardown (releases GIL while joining)
+    /// Graceful drain and teardown (releases GIL while draining and joining)
     #[pyo3(text_signature = "(self)")]
     pub fn close(&mut self, py: Python<'_>) -> PyResult<()> {
-        // Take ownership of the runtime parts so we can drop the sender
-        if let Some(rt) = self.runtime.take() {
-            let StreamRuntime {
-                runtime_handle: _,
-                cancel_token: _,
-                ingest_tx,
-                runtime_exited_rx,
-            } = rt;
+        if let Some(StreamRuntime {
+            stream,
+            shutdown_tx,
+        }) = self.runtime.take()
+        {
+            // Drop the stream first: its own `Drop` waits for every buffered point to be uploaded,
+            // and those uploads run on the runtime we are about to shut down.
+            info!("Dropping stream to drain buffered points");
+            py.detach(|| drop(stream));
 
-            // Close the data path so the worker's recv() returns None and exits
-            info!("Signalling shutdown: dropping ingest sender to initiate drain");
-            drop(ingest_tx);
-
-            // Wait for the async worker to finish draining (releases GIL)
-            info!("Awaiting async worker exit");
-            py.detach(|| {
-                let _ = runtime_exited_rx.blocking_recv();
-            });
+            info!("Signalling runtime thread to shut down");
+            let _ = shutdown_tx.send(());
         }
 
         // Join the runtime thread (releases GIL)
@@ -249,15 +236,14 @@ impl PyNominalDatasetStream {
         Ok(())
     }
 
-    /// Fast cancellation (used by SIGINT handler)
+    /// Teardown used by the SIGINT handler.
+    ///
+    /// NOTE: this still drains buffered points -- it is currently just `close`. Interrupting a
+    /// drain in progress needs cancellation support in the underlying stream.
     #[pyo3(text_signature = "(self)")]
     pub fn cancel(&mut self, py: Python<'_>) -> PyResult<()> {
-        // Tell async worker to quickly cancel
-        if let Some(rt) = &self.runtime {
-            info!("Cancel requested; signalling cancellation token");
-            rt.cancel_token.cancel();
-        } else {
-            warn!("Cancel requested, but runtime  not open...");
+        if self.runtime.is_none() {
+            warn!("Cancel requested, but stream not open...");
         }
 
         self.close(py)
@@ -274,7 +260,7 @@ impl PyNominalDatasetStream {
     ) -> PyResult<()> {
         let ts = parse_timestamp(timestamp);
         let ch = description_with_tags(channel_name, tags);
-        self.send_one(py, extract_single_enqueue_item(ch, ts, value)?)
+        self.push_one(py, ch, extract_single_points(ts, value)?)
     }
 
     #[pyo3(signature = (channel_name, timestamps, values, tags=None), text_signature = "(self, channel_name, timestamps, values, tags=None)")]
@@ -288,7 +274,7 @@ impl PyNominalDatasetStream {
     ) -> PyResult<()> {
         let tss = extract_vec_ts(timestamps);
         let ch = description_with_tags(channel_name, tags);
-        self.send_one(py, extract_series_enqueue_item(ch, tss, values)?)
+        self.push_one(py, ch, extract_series_points(tss, values)?)
     }
 
     #[pyo3(signature = (timestamp, channel_values, tags=None), text_signature = "(self, timestamp, channel_values, tags=None)")]
@@ -300,15 +286,20 @@ impl PyNominalDatasetStream {
         tags: Option<HashMap<String, String>>,
     ) -> PyResult<()> {
         let ts = parse_timestamp(timestamp);
-        let mut items: Vec<EnqueueItem> = Vec::with_capacity(channel_values.len());
+        // built once for the whole record rather than per channel
+        let tags = into_tag_map(tags);
+        let mut entries: Vec<(ChannelDescriptor, PointsType)> =
+            Vec::with_capacity(channel_values.len());
 
         for (k, v) in channel_values {
-            let ch_name: String = k.extract()?;
-            let ch = description_with_tags(ch_name.as_str(), tags.clone()); // same tags for all entries
-            items.push(extract_single_enqueue_item(ch, ts, &v)?);
+            let ch = ChannelDescriptor {
+                name: k.extract()?,
+                tags: tags.clone(),
+            };
+            entries.push((ch, extract_single_points(ts, &v)?));
         }
 
-        self.send_many(py, items)
+        self.push_many(py, entries)
     }
 
     #[pyo3(
@@ -329,7 +320,7 @@ impl PyNominalDatasetStream {
 
         let ts = parse_timestamp(timestamp);
         let ch = description_with_tags(channel_name, tags);
-        self.send_one(py, single_struct(ch, ts, json_string))
+        self.push_one(py, ch, single_struct(ts, json_string))
     }
 
     #[pyo3(
@@ -346,7 +337,7 @@ impl PyNominalDatasetStream {
     ) -> PyResult<()> {
         let ts = parse_timestamp(timestamp);
         let ch = description_with_tags(channel_name, tags);
-        self.send_one(py, single_double_array(ch, ts, value))
+        self.push_one(py, ch, single_double_array(ts, value))
     }
 
     #[pyo3(
@@ -363,7 +354,7 @@ impl PyNominalDatasetStream {
     ) -> PyResult<()> {
         let ts = parse_timestamp(timestamp);
         let ch = description_with_tags(channel_name, tags);
-        self.send_one(py, single_string_array(ch, ts, value))
+        self.push_one(py, ch, single_string_array(ts, value))
     }
 
     fn __enter__<'py>(mut slf: PyRefMut<'py, Self>) -> PyResult<PyRefMut<'py, Self>> {

--- a/py-nominal-streaming/src/point.rs
+++ b/py-nominal-streaming/src/point.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use nominal_api::tonic::google::protobuf::Timestamp;
 use nominal_streaming::prelude::*;
@@ -26,11 +27,13 @@ pub fn parse_timestamp(timestamp: u64) -> Timestamp {
 /// with `tags={}` lands in one series rather than splitting into two. Both encode to an empty tag
 /// map on the wire, so this is purely about keying the buffer consistently.
 ///
-/// Callers writing many channels at once should call this once and clone the result, rather than
-/// rebuilding the map per channel.
-pub fn into_tag_map(tags: Option<HashMap<String, String>>) -> Option<BTreeMap<String, String>> {
+/// Callers writing many channels at once should call this once and clone the result: the clone is
+/// a refcount bump, so every channel in a wide record can share one map.
+pub fn into_tag_map(
+    tags: Option<HashMap<String, String>>,
+) -> Option<Arc<BTreeMap<String, String>>> {
     tags.filter(|tags| !tags.is_empty())
-        .map(|tags| tags.into_iter().collect())
+        .map(|tags| Arc::new(tags.into_iter().collect()))
 }
 
 /// Build a ChannelDescriptor from channel name and optional tags.

--- a/py-nominal-streaming/src/point.rs
+++ b/py-nominal-streaming/src/point.rs
@@ -1,9 +1,11 @@
 //! Helpers for translating Python arguments into nominal_streaming types.
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 use nominal_api::tonic::google::protobuf::Timestamp;
 use nominal_streaming::prelude::*;
+use nominal_streaming::types::IntoPoints;
 use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -18,44 +20,28 @@ pub fn parse_timestamp(timestamp: u64) -> Timestamp {
     Timestamp { seconds, nanos }
 }
 
+/// Convert python tags into the descriptor's tag representation.
+///
+/// Absent and empty tags both become `None` so that the same channel written with `tags=None` and
+/// with `tags={}` lands in one series rather than splitting into two. Both encode to an empty tag
+/// map on the wire, so this is purely about keying the buffer consistently.
+///
+/// Callers writing many channels at once should call this once and clone the result, rather than
+/// rebuilding the map per channel.
+pub fn into_tag_map(tags: Option<HashMap<String, String>>) -> Option<BTreeMap<String, String>> {
+    tags.filter(|tags| !tags.is_empty())
+        .map(|tags| tags.into_iter().collect())
+}
+
 /// Build a ChannelDescriptor from channel name and optional tags.
 pub fn description_with_tags(
     name: &str,
     tags: Option<HashMap<String, String>>,
 ) -> ChannelDescriptor {
-    ChannelDescriptor::with_tags(
-        name.to_string(),
-        tags.map_or_else(Vec::new, |t| t.into_iter().collect()),
-    )
-}
-
-/// The typed payload that crosses the sync => async boundary.
-#[derive(Clone, Debug)]
-pub enum EnqueueItem {
-    Doubles {
-        ch: ChannelDescriptor,
-        points: Vec<DoublePoint>,
-    },
-    Ints {
-        ch: ChannelDescriptor,
-        points: Vec<IntegerPoint>,
-    },
-    Strings {
-        ch: ChannelDescriptor,
-        points: Vec<StringPoint>,
-    },
-    Structs {
-        ch: ChannelDescriptor,
-        points: Vec<StructPoint>,
-    },
-    DoubleArrays {
-        ch: ChannelDescriptor,
-        points: Vec<DoubleArrayPoint>,
-    },
-    StringArrays {
-        ch: ChannelDescriptor,
-        points: Vec<StringArrayPoint>,
-    },
+    ChannelDescriptor {
+        name: name.to_string(),
+        tags: into_tag_map(tags),
+    }
 }
 
 /// Ensure the given lists of timestamps and values have the same length
@@ -106,101 +92,78 @@ where
 
 // ---- Single-point constructors ----------------------------------------------
 
-pub fn single_double(ch: ChannelDescriptor, ts: Timestamp, v: f64) -> EnqueueItem {
-    EnqueueItem::Doubles {
-        ch,
-        points: vec![DoublePoint {
-            timestamp: Some(ts),
-            value: v,
-        }],
-    }
-}
-pub fn single_int(ch: ChannelDescriptor, ts: Timestamp, v: i64) -> EnqueueItem {
-    EnqueueItem::Ints {
-        ch,
-        points: vec![IntegerPoint {
-            timestamp: Some(ts),
-            value: v,
-        }],
-    }
-}
-pub fn single_string(ch: ChannelDescriptor, ts: Timestamp, v: String) -> EnqueueItem {
-    EnqueueItem::Strings {
-        ch,
-        points: vec![StringPoint {
-            timestamp: Some(ts),
-            value: v,
-        }],
-    }
-}
-pub fn single_struct(ch: ChannelDescriptor, ts: Timestamp, json_string: String) -> EnqueueItem {
-    EnqueueItem::Structs {
-        ch,
-        points: vec![StructPoint {
-            timestamp: Some(ts),
-            json_string,
-        }],
-    }
+pub fn single_double(ts: Timestamp, v: f64) -> PointsType {
+    vec![DoublePoint {
+        timestamp: Some(ts),
+        value: v,
+    }]
+    .into_points()
 }
 
-pub fn single_double_array(ch: ChannelDescriptor, ts: Timestamp, value: Vec<f64>) -> EnqueueItem {
-    EnqueueItem::DoubleArrays {
-        ch,
-        points: vec![DoubleArrayPoint {
-            timestamp: Some(ts),
-            value,
-        }],
-    }
+pub fn single_int(ts: Timestamp, v: i64) -> PointsType {
+    vec![IntegerPoint {
+        timestamp: Some(ts),
+        value: v,
+    }]
+    .into_points()
 }
 
-pub fn single_string_array(
-    ch: ChannelDescriptor,
-    ts: Timestamp,
-    value: Vec<String>,
-) -> EnqueueItem {
-    EnqueueItem::StringArrays {
-        ch,
-        points: vec![StringArrayPoint {
-            timestamp: Some(ts),
-            value,
-        }],
-    }
+pub fn single_string(ts: Timestamp, v: String) -> PointsType {
+    vec![StringPoint {
+        timestamp: Some(ts),
+        value: v,
+    }]
+    .into_points()
+}
+
+pub fn single_struct(ts: Timestamp, json_string: String) -> PointsType {
+    vec![StructPoint {
+        timestamp: Some(ts),
+        json_string,
+    }]
+    .into_points()
+}
+
+pub fn single_double_array(ts: Timestamp, value: Vec<f64>) -> PointsType {
+    vec![DoubleArrayPoint {
+        timestamp: Some(ts),
+        value,
+    }]
+    .into_points()
+}
+
+pub fn single_string_array(ts: Timestamp, value: Vec<String>) -> PointsType {
+    vec![StringArrayPoint {
+        timestamp: Some(ts),
+        value,
+    }]
+    .into_points()
 }
 
 // ---- Series (timestamps + values) constructors ------------------------------
 
-pub fn series_doubles(
-    ch: ChannelDescriptor,
-    tss: Vec<Timestamp>,
-    vals: Vec<f64>,
-) -> PyResult<EnqueueItem> {
-    let points = make_points(tss, vals, |ts, v| DoublePoint {
+pub fn series_doubles(tss: Vec<Timestamp>, vals: Vec<f64>) -> PyResult<PointsType> {
+    Ok(make_points(tss, vals, |ts, v| DoublePoint {
         timestamp: Some(ts),
         value: v,
-    })?;
-    Ok(EnqueueItem::Doubles { ch, points })
+    })?
+    .into_points())
 }
-pub fn series_ints(
-    ch: ChannelDescriptor,
-    tss: Vec<Timestamp>,
-    vals: Vec<i64>,
-) -> PyResult<EnqueueItem> {
-    let points = make_points(tss, vals, |ts, v| IntegerPoint {
+
+pub fn series_ints(tss: Vec<Timestamp>, vals: Vec<i64>) -> PyResult<PointsType> {
+    Ok(make_points(tss, vals, |ts, v| IntegerPoint {
         timestamp: Some(ts),
         value: v,
-    })?;
-    Ok(EnqueueItem::Ints { ch, points })
+    })?
+    .into_points())
 }
-pub fn series_strings(
-    ch: ChannelDescriptor,
-    tss: Vec<Timestamp>,
-    vals: Vec<String>,
-) -> PyResult<EnqueueItem> {
-    let points = make_points(tss, vals, |ts, v| StringPoint {
+
+pub fn series_strings(tss: Vec<Timestamp>, vals: Vec<String>) -> PyResult<PointsType> {
+    Ok(make_points(tss, vals, |ts, v| StringPoint {
         timestamp: Some(ts),
         value: v,
-    })?;
-    Ok(EnqueueItem::Strings { ch, points })
+    })?
+    .into_points())
 }
 
 // ---- Python collection helpers ----------------------------------------------

--- a/py-nominal-streaming/src/runtime.rs
+++ b/py-nominal-streaming/src/runtime.rs
@@ -1,54 +1,48 @@
-//! Helpers for managing tokio runtime under the hood for the lifespan of a stream used by python.
+//! Helpers for managing the tokio runtime that backs a stream's uploader for the lifespan of a
+//! stream used by python.
+//!
+//! Note that data does *not* travel through this runtime. `NominalDatasetStream::enqueue` is
+//! synchronous -- a buffer lock and a `Vec` push -- so python threads call it directly and the
+//! runtime is only ever used by the uploader to issue requests.
 
+use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::thread::{self};
 
 use anyhow::anyhow;
 use anyhow::Result;
+use nominal_streaming::prelude::NominalDatasetStream;
 use tokio::runtime::Builder;
-use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::info;
 
 use crate::lazy_dataset_stream_builder::LazyDatasetStreamBuilder;
-use crate::point::EnqueueItem;
 
-/// Struct encompassing all of the components of the runtime that the python-facing layer needs to interact with
+/// The parts of a running stream that the python-facing layer needs to interact with.
 pub struct StreamRuntime {
-    /// Tokio runtime handle to spawn / drive async work
-    pub runtime_handle: tokio::runtime::Handle,
-    /// Cancellation token to signal immediate teardown within workers
-    // TODO(drake): flush through to underlying NominalDatasetStream for instantaneous exit
-    pub cancel_token: CancellationToken,
-    /// Async queue for ingesting data into the runtime.
-    /// Data from Python enters this queue, where the runtime worker then forwards the data into the underlying NominalDatasetStream
-    pub ingest_tx: mpsc::Sender<EnqueueItem>,
-    /// Async receiver for when the async worker has fully drained and exited
-    pub runtime_exited_rx: oneshot::Receiver<()>,
+    /// The underlying stream. Points are pushed straight into this from whichever python thread
+    /// called `enqueue`.
+    pub stream: Arc<NominalDatasetStream>,
+    /// Fire to let the runtime thread drop its tokio runtime and exit.
+    ///
+    /// Must not be fired until `stream` has been dropped: the uploader issues its requests on that
+    /// runtime, including the ones that drain the final buffers.
+    pub shutdown_tx: oneshot::Sender<()>,
 }
 
-/// Create a background thread that manages a tokio runtime and in a tight loop pulls
-/// incoming data from a queue and forwards into the underlying rust streaming client
+/// Start a background thread owning a tokio runtime for the stream's uploader, build the stream on
+/// that runtime, and hand the stream back to the caller.
 pub fn spawn_runtime_worker(
     builder: LazyDatasetStreamBuilder,
 ) -> Result<(JoinHandle<()>, StreamRuntime)> {
-    let (rt_info_tx, rt_info_rx) = crossbeam_channel::bounded::<StreamRuntime>(1);
+    let (rt_info_tx, rt_info_rx) = crossbeam_channel::bounded::<Result<StreamRuntime>>(1);
 
     let num_workers = builder
         .opts
         .as_ref()
         .map(|o| o.num_runtime_workers)
         .unwrap_or_else(|| thread::available_parallelism().unwrap().get());
-
-    // TODO(drake): flush configuration through
-    // let async_cap = builder
-    //     .opts
-    //     .as_ref()
-    //     .map(|o| o.async_buffer_cap())
-    //     .unwrap_or(4);
-    let async_cap = 4;
 
     let join = thread::spawn(move || {
         let runtime = Builder::new_multi_thread()
@@ -58,72 +52,35 @@ pub fn spawn_runtime_worker(
             .build()
             .expect("tokio runtime failed to initialize");
 
-        // Clone the handle before block_on so we don't capture Runtime
-        let runtime_handle = runtime.handle().clone();
-        let cancel_token = CancellationToken::new();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
-        // Channel to communicate items to be enqueued into Rust from Python
-        let (ingest_tx, mut ingest_rx) = mpsc::channel::<EnqueueItem>(async_cap);
-
-        // Channel to communicate that the async worker has completed draining the queue & shutdown
-        let (runtime_exited_tx, runtime_exited_rx) = oneshot::channel::<()>();
-
-        // Main runtime loop
-        runtime.block_on(async move {
-            // Token that allows for cancelling the bridge process
-            // If the parent token gets cancelled, this worker will cancel too.
-            let cancel_child = cancel_token.child_token();
-
-            // Attempt to build the stream using the *cloned* handle.
-            let maybe_stream = builder.build(runtime_handle.clone());
-
-            // Pass runtime parts back to creator
-            let _ = rt_info_tx.send(StreamRuntime { runtime_handle, cancel_token: cancel_child.clone(), ingest_tx, runtime_exited_rx });
-
-            // Build the underlying stream using a cloned handle
-            let stream = match maybe_stream {
-                Ok(s) => s,
-                Err(e) => {
-                    let _ = runtime_exited_tx.send(());
-                    error!("Failed to start underlying stream: {e}");
-                    return;
-                }
-            };
-
-            // Forwarding loop
-            loop {
-                tokio::select! {
-                    _ = cancel_child.cancelled() => {
-                        info!("Cancellation token received! Stopping runtime...");
-                        break;
-                    },
-                    maybe_item = ingest_rx.recv() => {
-                        match maybe_item {
-                            Some(EnqueueItem::Doubles      { ch, points }) => { stream.enqueue(&ch, points); }
-                            Some(EnqueueItem::Ints         { ch, points }) => { stream.enqueue(&ch, points); }
-                            Some(EnqueueItem::Strings      { ch, points }) => { stream.enqueue(&ch, points); }
-                            Some(EnqueueItem::Structs      { ch, points }) => { stream.enqueue(&ch, points); }
-                            Some(EnqueueItem::DoubleArrays { ch, points }) => { stream.enqueue(&ch, points); }
-                            Some(EnqueueItem::StringArrays { ch, points }) => { stream.enqueue(&ch, points); }
-                            None => {
-                                info!("Empty enqueue item received! Stopping runtime...");
-                                break;
-                            },
-                        }
-                    }
-                }
+        // Build the stream on this runtime's handle and hand it to the caller. This thread keeps no
+        // reference of its own, so the caller's drop is what drains the stream.
+        match builder.build(runtime.handle().clone()) {
+            Ok(stream) => {
+                let _ = rt_info_tx.send(Ok(StreamRuntime {
+                    stream: Arc::new(stream),
+                    shutdown_tx,
+                }));
             }
+            Err(e) => {
+                error!("Failed to start underlying stream: {e}");
+                let _ = rt_info_tx.send(Err(e));
+                return;
+            }
+        }
 
-            // TODO (drake): consider adding error handling around send() call
-            info!("Worker loop exited; signalling runtime exit.");
-            let _ = runtime_exited_tx.send(());
+        // Hold the runtime open until close() says the uploader is finished with it.
+        info!("Runtime thread parked awaiting shutdown");
+        runtime.block_on(async move {
+            let _ = shutdown_rx.await;
         });
+        info!("Runtime thread shutting down");
     });
 
-    // Receive information about runtime once initialization has finished
     let rt_info = rt_info_rx
         .recv()
-        .map_err(|_| anyhow!("Failed to init runtime"))?;
+        .map_err(|_| anyhow!("Failed to init runtime"))??;
 
     info!("Runtime worker successfully started");
     Ok((join, rt_info))


### PR DESCRIPTION
Two commits, both aimed at making bulk writes cost what they should. Measured against a local
file target (no uploader) at `--release` on both sides.

## What was wrong

Every enqueued point crossed a hardcoded `bounded(4)` tokio mpsc channel drained by a single
forwarding task, costing a park/unpark round-trip **per `EnqueueItem`** rather than per call. That
made `enqueue_from_dict` — one boundary crossing, but one item per channel — no faster than looping
over `enqueue`, and measurably *slower* on a 6,480-channel record (10,923us vs 8,964us).

The channel bought nothing: `NominalDatasetStream::enqueue` is synchronous and `Sync`, so python
threads can call it directly under `py.detach()`. The tokio runtime stays, but only for the uploader.

With that gone, the next cost became visible: a wide record is thousands of channels sharing one
timestamp and one set of tags, but `ChannelDescriptor` owned its tags, so each channel copied the
map — once building the descriptor, once more when the buffer first saw the channel.

## Results

Three write shapes, 200-sample or min-of-N as noted:

| shape | before | after |
| --- | ---: | ---: |
| 6,480 channels @ one timestamp | 9,460us | **932us** (10.1x) |
| 10,000 points @ one channel | 560us | **235us** (2.4x) |
| single point | 1.55us | **0.258us** (6.0x) |

Realistic workload — 6,480 tagged channels at 10Hz, 200 samples, median per call:

| max_request_delay | main | + direct enqueue | + shared tags |
| ---: | ---: | ---: | ---: |
| 0.1s | 10,791us | 4,862us | **1,421us** (7.6x) |
| 1.0s | 12,569us | 5,457us | **3,221us** (3.9x) |

## Also in here

- Absent and empty tags both normalize to `None`, so a channel written with `tags=None` and one
  written with `tags={}` share a series instead of splitting into two. Identical on the wire.
- Python-side: skip timestamp normalization when the caller already passed integral nanoseconds,
  and stop copying the caller's mapping in `enqueue_from_dict` (it can hold thousands of channels).
- `open()` now raises when the stream fails to build, rather than logging and returning a stream
  that rejects every write.
- Concurrent ingest from several python threads now contends only on the buffer lock, rather than
  serializing through one forwarding task.

## Breaking

`ChannelDescriptor::tags` is now `Option<Arc<BTreeMap<String, String>>>`. `new()` and `with_tags()`
are unaffected; only code reading or assigning the field directly needs a change.

## Verification

- Avro round-trip output is byte-identical to `main` across every write shape: scalars, series,
  wide dicts, tags, structs, arrays, and non-integral timestamps.
- 21 cargo tests pass, including two new ones covering `enqueue_many`.
- 8-thread concurrent ingest lands exactly 40,400 points, no loss or duplication.
- ruff, mypy, and clippy clean (one pre-existing clippy warning at `lib.rs:267`, untouched).

## Known follow-up

At longer `max_request_delay` the per-call cost rises, but I want to be careful about how strongly
I state it: repeating the same measurement on the same build gives medians that vary by up to 2x at
delays >= 0.5s (e.g. 1,727us / 3,187us / 3,375us across three runs at 2.0s). The 0.1s figures above
are well outside that band and are safe to rely on; the 1.0s figures are directionally right but
their precision is not.

What is clear from a lower-variance measurement (flushing disabled entirely): a tagged wide write
costs 1,489us, and at `max_request_delay=0.1s` it costs 1,549us -- so at the default setting there
is essentially nothing left on the table. Longer delays cost more than that floor.

One mechanism is identified but not yet quantified reliably: `batch_processor` parks for the full
`max_request_delay` after each flush and is only woken early by a write that no longer fits, so a
writer that fills the buffer can block for the remainder of the delay. Fixing that is a separate
change and needs a lower-variance harness than the one used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
